### PR TITLE
Create rasgo_datetrunc.sql.j2

### DIFF
--- a/Transforms/column_operations/rasgo_datetrunc.sql
+++ b/Transforms/column_operations/rasgo_datetrunc.sql
@@ -1,6 +1,7 @@
 -- Args: {{date_part}}, {{date_column}}
 -- date_part: ['year','month','day','week','quarter','hour','minute','second','millisecond','microsecond']
 
+{% set date_list = None %}
 {%- if date_column is string -%}
     {% set date_list = [date_column] %}
 {% else %}
@@ -11,4 +12,4 @@ SELECT *,
 {%- for col in date_list -%}
     DATE_TRUNC({{date_part}}, {{col}}) as {{col}}_{{date_part}} {{ ", " if not loop.last else "" }}
 {%- endfor -%}
-from {{source_table}}
+from {{ source_table }}


### PR DESCRIPTION
adding a date_trunc transform

question that applies to more than just this transform:
will looping through work if only one column is passed, instead of a list? guessing not but what's the easiest way to make it variable so that we can pass in either one value or a list of values and have both work?