### PR TITLE
Aggregate string

### DIFF
--- a/column_transforms/datetrunc/datetrunc.yaml
+++ b/column_transforms/datetrunc/datetrunc.yaml
@@ -1,6 +1,8 @@
 name: datetrunc
 description: |
   Truncates a date to the datepart you specify. For example, if you truncate the date '10-31-2022' to the 'month', you would get '10-1-2022'.
+
+  For a list of valid dateparts, refer to [Supported Date and Time Parts](https://docs.snowflake.com/en/sql-reference/functions-date-time.html#label-supported-date-time-parts)
 arguments:
   dates:
     type: datepart_dict

--- a/docs/table_transforms/aggregate_string.md
+++ b/docs/table_transforms/aggregate_string.md
@@ -1,0 +1,37 @@
+
+
+# aggregate_string
+
+Aggregate strings across rows by concatenating them together, and grouping by other columns.
+
+Uses a text separator to aggregate the string values together, and returns a single column where the rows are the aggregated strings.
+
+
+## Parameters
+
+|  Argument  |    Type     |                                                         Description                                                          |
+| ---------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| agg_column | column      | Column with string values to aggregate                                                                                       |
+| sep        | value       | Text separator to use when aggregating the strings, i.e. ', '.                                                               |
+| group_by   | column_list | Columns to group by when applying the aggregation.                                                                           |
+| distinct   | boolean     | If you want to collapse multiple rows of the same string value into a single distinct value, use TRUE. Otherwise, use FALSE. |
+| order      | value       | ASC or DESC, to set the alphabetical order of the agg_column when aggregating it                                             |
+
+
+## Example
+
+```python
+product = rasgo.get.dataset(id)
+
+ds2 = product.aggregate_string(group_by=['PRODUCTLINE'],
+                agg_column='ENGLISHPRODUCTNAME',
+                sep=', ',
+                distinct='FALSE',
+                order='ASC')
+ds2.preview()
+```
+
+## Source Code
+
+{% embed url="https://github.com/rasgointelligence/RasgoUDTs/blob/main/table_transforms/aggregate_string/aggregate_string.sql" %}
+

--- a/table_transforms/aggregate_string/aggregate_string.sql
+++ b/table_transforms/aggregate_string/aggregate_string.sql
@@ -1,0 +1,5 @@
+SELECT {{ group_by | join(', ') }},
+listagg({{ 'distinct ' if distinct else ''}} {{agg_column}}, '{{sep}}')
+WITHIN group (order by {{agg_column}} {{order}}) as {{agg_column}}_listagg
+FROM {{ source_table }}
+GROUP BY {{ group_by | join(', ') }}

--- a/table_transforms/aggregate_string/aggregate_string.yaml
+++ b/table_transforms/aggregate_string/aggregate_string.yaml
@@ -1,0 +1,30 @@
+name: aggregate_string
+description: |
+  Aggregate strings across rows by concatenating them together, and grouping by other columns.
+
+  Uses a text separator to aggregate the string values together, and returns a single column where the rows are the aggregated strings.
+arguments:
+  agg_column:
+    type: column
+    description: Column with string values to aggregate
+  sep:
+    type: value
+    description: Text separator to use when aggregating the strings, i.e. ', '.
+  group_by:
+    type: column_list
+    description: Columns to group by when applying the aggregation.
+  distinct:
+    type: boolean
+    description: If you want to collapse multiple rows of the same string value into a single distinct value, use TRUE. Otherwise, use FALSE.
+  order:
+    type: value
+    description: ASC or DESC, to set the alphabetical order of the agg_column when aggregating it
+example_code: |
+  product = rasgo.get.dataset(id)
+
+  ds2 = product.aggregate_string(group_by=['PRODUCTLINE'],
+                  agg_column='ENGLISHPRODUCTNAME',
+                  sep=', ',
+                  distinct='FALSE',
+                  order='ASC')
+  ds2.preview()


### PR DESCRIPTION
to test:

`internet_sales = rasgo.get.dataset(74)

ds2 = internet_sales.new_stringagg(group_by=['PRODUCTKEY'],
    agg_column='ORDERDATEKEY',
    sep=', ',
    distinct='FALSE',
    order='ASC')

ds2.preview()`