### PR TITLE
Add is optional flag to udt args

### DIFF
--- a/column_transforms/drop_columns/drop_columns.yaml
+++ b/column_transforms/drop_columns/drop_columns.yaml
@@ -8,9 +8,11 @@ arguments:
   include_cols:
     type: column_list
     description: A list of the columns from the dataset you want to keep.
+    is_optional: true
   exclude_cols:
     type: column_list
     description: A list of the columns from the dataset you want to drop. Any columns not in the exclude_cols list will be kept.
+    is_optional: true
 example_code: |
   ds = rasgo.get.dataset(id)
 

--- a/column_transforms/impute/impute.yaml
+++ b/column_transforms/impute/impute.yaml
@@ -7,6 +7,7 @@ arguments:
   flag_missing_vals:
     type: boolean
     description: If True/set will create a new column for every one imputing that has 1 if column in the impuation dict was NULL, 0 if it wasn't. This columns will be named like '<col_name>_missing_flag'.
+    is_optional: true
 example_code: |
   ds = rasgo.get.dataset(id)
   

--- a/column_transforms/min_max_scaler/min_max_scaler.yaml
+++ b/column_transforms/min_max_scaler/min_max_scaler.yaml
@@ -10,9 +10,11 @@ arguments:
   minimums:
     type: value_list
     description: An optional argument representing a list of the static minimums to use for each column in columns_to_scale. If omitted, the minimums are calculated directly off each column.
+    is_optional: true
   maximums:
     type: value_list
     description: An optional argument representing a list of the static maximums to use for each column in columns_to_scale. If omitted, the values are calculated directly off each column.
+    is_optional: true
 example_code: |
   ds = rasgo.get.dataset(id)
 

--- a/column_transforms/standard_scaler/standard_scaler.yaml
+++ b/column_transforms/standard_scaler/standard_scaler.yaml
@@ -10,9 +10,11 @@ arguments:
   averages:
     type: value_list
     description: An optional argument representing a list of the static averages to use for each column in columns_to_scale. If omitted, the averages are calculated directly off each column.
+    is_optional: true
   standarddevs:
     type: value_list
     description: An optional argument representing a list of the static standard deviations to use for each column in columns_to_scale. If omitted, the values are calculated directly off each column.
+    is_optional: true
 example_code: |
   ds = rasgo.get.dataset(id)
 

--- a/column_transforms/substring/substring.yaml
+++ b/column_transforms/substring/substring.yaml
@@ -11,6 +11,7 @@ arguments:
   end_pos:
     type: value
     description: The number of characters to select. If left empty, select through the end of the string.
+    is_optional: true
 example_code: |
   ds = rasgo.get.dataset(id)
 

--- a/column_transforms/train_test_split/train_test_split.yaml
+++ b/column_transforms/train_test_split/train_test_split.yaml
@@ -6,7 +6,8 @@ description: |
 arguments:
   order_by:
     type: column_list
-    description: optional argument that affects the train/test split method applied. if needed, pass the names of column(s) you want to order by when applying the split.
+    description: Optional argument that affects the train/test split method applied. if needed, pass the names of column(s) you want to order by when applying the split.
+    is_optional: true
   train_percent:
     type: value
     description: Percent of the data you want in the train set, expressed as a decimal (i.e. .8). The rest of the rows will be included in the test set.

--- a/docs/column_transforms/bin.md
+++ b/docs/column_transforms/bin.md
@@ -15,11 +15,11 @@ The `equalwidth` method will calculate the boundaries of the bins such that they
 
 ## Parameters
 
-|   Argument   |  Type  |                        Description                        |
-| ------------ | ------ | --------------------------------------------------------- |
-| type         | string | binning algorithm to use; must be `ntile` or `equalwidth` |
-| bucket_count | int    | the number of equal-width bins to use                     |
-| column       | column | which column to bucket                                    |
+|   Argument   |  Type  |                        Description                        | Is Optional |
+| ------------ | ------ | --------------------------------------------------------- | ----------- |
+| type         | string | binning algorithm to use; must be `ntile` or `equalwidth` |             |
+| bucket_count | int    | the number of equal-width bins to use                     |             |
+| column       | column | which column to bucket                                    |             |
 
 
 ## Example

--- a/docs/column_transforms/cast.md
+++ b/docs/column_transforms/cast.md
@@ -7,9 +7,9 @@ Cast selected columns to a new type
 
 ## Parameters
 
-| Argument |       Type        |                                    Description                                     |
-| -------- | ----------------- | ---------------------------------------------------------------------------------- |
-| casts    | column_value_dict | A dict where the keys are columns and the values are the new type to cast them to. |
+| Argument |       Type        |                                    Description                                     | Is Optional |
+| -------- | ----------------- | ---------------------------------------------------------------------------------- | ----------- |
+| casts    | column_value_dict | A dict where the keys are columns and the values are the new type to cast them to. |             |
 
 
 ## Example

--- a/docs/column_transforms/concat.md
+++ b/docs/column_transforms/concat.md
@@ -9,9 +9,9 @@ Pass in a list named "concat_list", containing the names of the columns and the 
 
 ## Parameters
 
-|  Argument   |    Type    |                    Description                     |
-| ----------- | ---------- | -------------------------------------------------- |
-| concat_list | mixed_list | A list representing each new column to be created. |
+|  Argument   |    Type    |                    Description                     | Is Optional |
+| ----------- | ---------- | -------------------------------------------------- | ----------- |
+| concat_list | mixed_list | A list representing each new column to be created. |             |
 
 
 ## Example

--- a/docs/column_transforms/datediff.md
+++ b/docs/column_transforms/datediff.md
@@ -6,11 +6,11 @@ Calculates the difference between two date, time, or timestamp expressions based
 
 ## Parameters
 
-| Argument  |    Type     |                                                                                Description                                                                                 |
-| --------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| date_part | date_part   | Must be one of the values listed in [Supported Date and Time Parts](https://docs.snowflake.com/en/sql-reference/functions-date-time.html#label-supported-date-time-parts)  |
-| date_1    | mixed_value | Date column to subtract from `date_val_2`. Can be a date column, date, time, or timestamp.                                                                                 |
-| date_2    | mixed_value | Date column to be subtracted by `date_val_1`. Can be a date column, date, time, or timestamp.                                                                              |
+| Argument  |    Type     |                                                                                Description                                                                                 | Is Optional |
+| --------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| date_part | date_part   | Must be one of the values listed in [Supported Date and Time Parts](https://docs.snowflake.com/en/sql-reference/functions-date-time.html#label-supported-date-time-parts)  |             |
+| date_1    | mixed_value | Date column to subtract from `date_val_2`. Can be a date column, date, time, or timestamp.                                                                                 |             |
+| date_2    | mixed_value | Date column to be subtracted by `date_val_1`. Can be a date column, date, time, or timestamp.                                                                              |             |
 
 
 ## Example

--- a/docs/column_transforms/datepart.md
+++ b/docs/column_transforms/datepart.md
@@ -9,9 +9,9 @@ An exhaustive list of valid date parts can be [found here](https://docs.snowflak
 
 ## Parameters
 
-| Argument |     Type      |                                              Description                                              |
-| -------- | ------------- | ----------------------------------------------------------------------------------------------------- |
-| dates    | datepart_dict | dict where keys are names of columns you want to date part and values are the desired date part grain |
+| Argument |     Type      |                                              Description                                              | Is Optional |
+| -------- | ------------- | ----------------------------------------------------------------------------------------------------- | ----------- |
+| dates    | datepart_dict | dict where keys are names of columns you want to date part and values are the desired date part grain |             |
 
 
 ## Example

--- a/docs/column_transforms/datetrunc.md
+++ b/docs/column_transforms/datetrunc.md
@@ -9,9 +9,9 @@ For a list of valid dateparts, refer to [Supported Date and Time Parts](https://
 
 ## Parameters
 
-| Argument |     Type      |                                                Description                                                 |
-| -------- | ------------- | ---------------------------------------------------------------------------------------------------------- |
-| dates    | datepart_dict | dict where the keys are names of column(s) you want to datetrunc and the values are the desired date grain |
+| Argument |     Type      |                                                Description                                                 | Is Optional |
+| -------- | ------------- | ---------------------------------------------------------------------------------------------------------- | ----------- |
+| dates    | datepart_dict | dict where the keys are names of column(s) you want to datetrunc and the values are the desired date grain |             |
 
 
 ## Example

--- a/docs/column_transforms/drop_columns.md
+++ b/docs/column_transforms/drop_columns.md
@@ -9,10 +9,10 @@ Passing both include_cols and exclude_cols will result in an error.
 
 ## Parameters
 
-|   Argument   |    Type     |                                                   Description                                                   |
-| ------------ | ----------- | --------------------------------------------------------------------------------------------------------------- |
-| include_cols | column_list | A list of the columns from the dataset you want to keep.                                                        |
-| exclude_cols | column_list | A list of the columns from the dataset you want to drop. Any columns not in the exclude_cols list will be kept. |
+|   Argument   |    Type     |                                                   Description                                                   | Is Optional |
+| ------------ | ----------- | --------------------------------------------------------------------------------------------------------------- | ----------- |
+| include_cols | column_list | A list of the columns from the dataset you want to keep.                                                        | True        |
+| exclude_cols | column_list | A list of the columns from the dataset you want to drop. Any columns not in the exclude_cols list will be kept. | True        |
 
 
 ## Example

--- a/docs/column_transforms/if_then.md
+++ b/docs/column_transforms/if_then.md
@@ -11,11 +11,11 @@ A default value for the new column should be set, as should the output column na
 
 ## Parameters
 
-|  Argument  |       Type       |                                                            Description                                                            |
-| ---------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| conditions | conditional_list | A nested list. In each inner list the first element would be the condition to check, and the second the value with which to fill. |
-| default    | mixed_value      | The default value with which to fill the new column. Please enclose fixed strings in quotes inside of the argument (e.g., below)  |
-| alias      | string           | The name of the output column in the new dataset.                                                                                 |
+|  Argument  |       Type       |                                                            Description                                                            | Is Optional |
+| ---------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| conditions | conditional_list | A nested list. In each inner list the first element would be the condition to check, and the second the value with which to fill. |             |
+| default    | mixed_value      | The default value with which to fill the new column. Please enclose fixed strings in quotes inside of the argument (e.g., below)  |             |
+| alias      | string           | The name of the output column in the new dataset.                                                                                 |             |
 
 
 ## Example

--- a/docs/column_transforms/impute.md
+++ b/docs/column_transforms/impute.md
@@ -6,10 +6,10 @@ Impute missing values in column/columns with the mean, median, mode, or a value
 
 ## Parameters
 
-|     Argument      |      Type       |                                                                                         Description                                                                                         |
-| ----------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| imputations       | imputation_dict | Dictionary with keys as column names to impute missing values for, and dictionary values the type of imputation stratgey ('mean', 'median', 'mode', <value>)                                |
-| flag_missing_vals | boolean         | If True/set will create a new column for every one imputing that has 1 if column in the impuation dict was NULL, 0 if it wasn't. This columns will be named like '<col_name>_missing_flag'. |
+|     Argument      |      Type       |                                                                                         Description                                                                                         | Is Optional |
+| ----------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| imputations       | imputation_dict | Dictionary with keys as column names to impute missing values for, and dictionary values the type of imputation stratgey ('mean', 'median', 'mode', <value>)                                |             |
+| flag_missing_vals | boolean         | If True/set will create a new column for every one imputing that has 1 if column in the impuation dict was NULL, 0 if it wasn't. This columns will be named like '<col_name>_missing_flag'. | True        |
 
 
 ## Example

--- a/docs/column_transforms/label_encode.md
+++ b/docs/column_transforms/label_encode.md
@@ -7,9 +7,9 @@ Encode target labels with value between 0 and n_classes-1. See scikit-learn's [L
 
 ## Parameters
 
-| Argument |  Type  |         Description         |
-| -------- | ------ | --------------------------- |
-| column   | column | Column name to label encode |
+| Argument |  Type  |         Description         | Is Optional |
+| -------- | ------ | --------------------------- | ----------- |
+| column   | column | Column name to label encode |             |
 
 
 ## Example

--- a/docs/column_transforms/lag.md
+++ b/docs/column_transforms/lag.md
@@ -6,12 +6,12 @@ Lag shifts your features on a partition index, creating a lookback feature offse
 
 ## Parameters
 
-| Argument  |    Type     |                                                                     Description                                                                     |
-| --------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| columns   | column_list | names of column(s) you want to lag                                                                                                                  |
-| amounts   | value_list  | Magnitude of amounts you want to use for the lag. Positive values result in a historical offset; negative amounts result in forward-looking offset. |
-| partition | column_list | name of column(s) to partition by for the lag                                                                                                       |
-| order_by  | column_list | name of column(s) to order by in the final data set                                                                                                 |
+| Argument  |    Type     |                                                                     Description                                                                     | Is Optional |
+| --------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| columns   | column_list | names of column(s) you want to lag                                                                                                                  |             |
+| amounts   | value_list  | Magnitude of amounts you want to use for the lag. Positive values result in a historical offset; negative amounts result in forward-looking offset. |             |
+| partition | column_list | name of column(s) to partition by for the lag                                                                                                       |             |
+| order_by  | column_list | name of column(s) to order by in the final data set                                                                                                 |             |
 
 
 ## Example

--- a/docs/column_transforms/levenshtein.md
+++ b/docs/column_transforms/levenshtein.md
@@ -6,10 +6,10 @@ Calculate the edit distance between pairwise combinations of string columns
 
 ## Parameters
 
-| Argument |    Type     |          Description          |
-| -------- | ----------- | ----------------------------- |
-| columns1 | column_list | first list of string columns  |
-| column2  | column_list | second list of string columns |
+| Argument |    Type     |          Description          | Is Optional |
+| -------- | ----------- | ----------------------------- | ----------- |
+| columns1 | column_list | first list of string columns  |             |
+| column2  | column_list | second list of string columns |             |
 
 
 ## Example

--- a/docs/column_transforms/math.md
+++ b/docs/column_transforms/math.md
@@ -6,9 +6,9 @@ Create one or more new columns
 
 ## Parameters
 
-| Argument |   Type    |                                         Description                                         |
-| -------- | --------- | ------------------------------------------------------------------------------------------- |
-| math_ops | math_list | List of math operations to generate new columns. Ex. ["<col_name> + 5", "<col_name> / 100"] |
+| Argument |   Type    |                                         Description                                         | Is Optional |
+| -------- | --------- | ------------------------------------------------------------------------------------------- | ----------- |
+| math_ops | math_list | List of math operations to generate new columns. Ex. ["<col_name> + 5", "<col_name> / 100"] |             |
 
 
 ## Example

--- a/docs/column_transforms/min_max_scaler.md
+++ b/docs/column_transforms/min_max_scaler.md
@@ -9,11 +9,11 @@ If you omit minimums and maximums, the function will compute the mins and maxes 
 
 ## Parameters
 
-|     Argument     |    Type     |                                                                                  Description                                                                                  |
-| ---------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| columns_to_scale | column_list | A list of numeric columns that you want to scale                                                                                                                              |
-| minimums         | value_list  | An optional argument representing a list of the static minimums to use for each column in columns_to_scale. If omitted, the minimums are calculated directly off each column. |
-| maximums         | value_list  | An optional argument representing a list of the static maximums to use for each column in columns_to_scale. If omitted, the values are calculated directly off each column.   |
+|     Argument     |    Type     |                                                                                  Description                                                                                  | Is Optional |
+| ---------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| columns_to_scale | column_list | A list of numeric columns that you want to scale                                                                                                                              |             |
+| minimums         | value_list  | An optional argument representing a list of the static minimums to use for each column in columns_to_scale. If omitted, the minimums are calculated directly off each column. | True        |
+| maximums         | value_list  | An optional argument representing a list of the static maximums to use for each column in columns_to_scale. If omitted, the values are calculated directly off each column.   | True        |
 
 
 ## Example

--- a/docs/column_transforms/moving_avg.md
+++ b/docs/column_transforms/moving_avg.md
@@ -6,12 +6,12 @@ generates moving averages per column and per window size
 
 ## Parameters
 
-|   Argument    |    Type     |                                Description                                 |
-| ------------- | ----------- | -------------------------------------------------------------------------- |
-| input_columns | column_list | names of column(s) you want to moving average                              |
-| window_sizes  | value_list  | the integer values for window sizes you want to use in your moving average |
-| order_by      | column_list | columns to order by, typically the date index of the table                 |
-| partition     | column_list | columns to partition the moving average by                                 |
+|   Argument    |    Type     |                                Description                                 | Is Optional |
+| ------------- | ----------- | -------------------------------------------------------------------------- | ----------- |
+| input_columns | column_list | names of column(s) you want to moving average                              |             |
+| window_sizes  | value_list  | the integer values for window sizes you want to use in your moving average |             |
+| order_by      | column_list | columns to order by, typically the date index of the table                 |             |
+| partition     | column_list | columns to partition the moving average by                                 |             |
 
 
 ## Example

--- a/docs/column_transforms/one_hot_encode.md
+++ b/docs/column_transforms/one_hot_encode.md
@@ -6,9 +6,9 @@ One hot encode a column and drop it from the dataset. Create a null value flag f
 
 ## Parameters
 
-| Argument |  Type  |          Description          |
-| -------- | ------ | ----------------------------- |
-| column   | column | Column name to one-hot encode |
+| Argument |  Type  |          Description          | Is Optional |
+| -------- | ------ | ----------------------------- | ----------- |
+| column   | column | Column name to one-hot encode |             |
 
 
 ## Example

--- a/docs/column_transforms/rename.md
+++ b/docs/column_transforms/rename.md
@@ -7,9 +7,9 @@ Rename columns by passing a renames dict.
 
 ## Parameters
 
-| Argument |       Type        |                                      Description                                       |
-| -------- | ----------------- | -------------------------------------------------------------------------------------- |
-| renames  | column_value_dict | A dict representing each existing column to be renamed and its corresponding new name. |
+| Argument |       Type        |                                      Description                                       | Is Optional |
+| -------- | ----------------- | -------------------------------------------------------------------------------------- | ----------- |
+| renames  | column_value_dict | A dict representing each existing column to be renamed and its corresponding new name. |             |
 
 
 ## Example

--- a/docs/column_transforms/standard_scaler.md
+++ b/docs/column_transforms/standard_scaler.md
@@ -9,11 +9,11 @@ If you omit averages and standarddevs, the function will compute the average and
 
 ## Parameters
 
-|     Argument     |    Type     |                                                                                      Description                                                                                       |
-| ---------------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| columns_to_scale | column_list | A list of numeric columns that you want to scale                                                                                                                                       |
-| averages         | value_list  | An optional argument representing a list of the static averages to use for each column in columns_to_scale. If omitted, the averages are calculated directly off each column.          |
-| standarddevs     | value_list  | An optional argument representing a list of the static standard deviations to use for each column in columns_to_scale. If omitted, the values are calculated directly off each column. |
+|     Argument     |    Type     |                                                                                      Description                                                                                       | Is Optional |
+| ---------------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| columns_to_scale | column_list | A list of numeric columns that you want to scale                                                                                                                                       |             |
+| averages         | value_list  | An optional argument representing a list of the static averages to use for each column in columns_to_scale. If omitted, the averages are calculated directly off each column.          | True        |
+| standarddevs     | value_list  | An optional argument representing a list of the static standard deviations to use for each column in columns_to_scale. If omitted, the values are calculated directly off each column. | True        |
 
 
 ## Example

--- a/docs/column_transforms/substring.md
+++ b/docs/column_transforms/substring.md
@@ -7,11 +7,11 @@ This function creates a new column that contains a substring of either a fixed v
 
 ## Parameters
 
-|  Argument  |  Type  |                                                                                                       Description                                                                                                       |
-| ---------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| target_col | column | A string column from which to subselect                                                                                                                                                                                 |
-| start_pos  | value  | The position of the string from which to begin selection. Index begins at 1, not 0. May be a negative number, in which case the value represents the positions from the end of the string from which to begin selection |
-| end_pos    | value  | The number of characters to select. If left empty, select through the end of the string.                                                                                                                                |
+|  Argument  |  Type  |                                                                                                       Description                                                                                                       | Is Optional |
+| ---------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| target_col | column | A string column from which to subselect                                                                                                                                                                                 |             |
+| start_pos  | value  | The position of the string from which to begin selection. Index begins at 1, not 0. May be a negative number, in which case the value represents the positions from the end of the string from which to begin selection |             |
+| end_pos    | value  | The number of characters to select. If left empty, select through the end of the string.                                                                                                                                | True        |
 
 
 ## Example

--- a/docs/column_transforms/target_encode.md
+++ b/docs/column_transforms/target_encode.md
@@ -9,10 +9,10 @@ See scikit-learn's [TargetEncoder](https://contrib.scikit-learn.org/category_enc
 
 ## Parameters
 
-| Argument |  Type  |                   Description                   |
-| -------- | ------ | ----------------------------------------------- |
-| column   | column | Column name to target encode                    |
-| target   | column | Numeric target column to use to create averages |
+| Argument |  Type  |                   Description                   | Is Optional |
+| -------- | ------ | ----------------------------------------------- | ----------- |
+| column   | column | Column name to target encode                    |             |
+| target   | column | Numeric target column to use to create averages |             |
 
 
 ## Example

--- a/docs/column_transforms/to_date.md
+++ b/docs/column_transforms/to_date.md
@@ -9,9 +9,9 @@ See [this Snowflake doc](https://docs.snowflake.com/en/user-guide/date-time-inpu
 
 ## Parameters
 
-| Argument |       Type        |                                              Description                                               |
-| -------- | ----------------- | ------------------------------------------------------------------------------------------------------ |
-| dates    | column_value_dict | dict where the values are the date columns and the keys are the date formats to use for the conversion |
+| Argument |       Type        |                                              Description                                               | Is Optional |
+| -------- | ----------------- | ------------------------------------------------------------------------------------------------------ | ----------- |
+| dates    | column_value_dict | dict where the values are the date columns and the keys are the date formats to use for the conversion |             |
 
 
 ## Example

--- a/docs/column_transforms/train_test_split.md
+++ b/docs/column_transforms/train_test_split.md
@@ -9,10 +9,10 @@ If you want a row-wise random sample applied, do not pass an order_by column. If
 
 ## Parameters
 
-|   Argument    |    Type     |                                                                       Description                                                                        |
-| ------------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| order_by      | column_list | Optional argument that affects the train/test split method applied. if needed, pass the names of column(s) you want to order by when applying the split. |
-| train_percent | value       | Percent of the data you want in the train set, expressed as a decimal (i.e. .8). The rest of the rows will be included in the test set.                  |
+|   Argument    |    Type     |                                                                       Description                                                                        | Is Optional |
+| ------------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| order_by      | column_list | Optional argument that affects the train/test split method applied. if needed, pass the names of column(s) you want to order by when applying the split. | True        |
+| train_percent | value       | Percent of the data you want in the train set, expressed as a decimal (i.e. .8). The rest of the rows will be included in the test set.                  |             |
 
 
 ## Example

--- a/docs/row_transforms/filter.md
+++ b/docs/row_transforms/filter.md
@@ -6,9 +6,9 @@ Apply one or more column filters to the dataset
 
 ## Parameters
 
-|     Argument      |    Type     |                                              Description                                              |
-| ----------------- | ----------- | ----------------------------------------------------------------------------------------------------- |
-| filter_statements | string_list | List of where statements filter the table by. Ex. ["<col_name> = 'string'", "<col_name> IS NOT NULL"] |
+|     Argument      |    Type     |                                              Description                                              | Is Optional |
+| ----------------- | ----------- | ----------------------------------------------------------------------------------------------------- | ----------- |
+| filter_statements | string_list | List of where statements filter the table by. Ex. ["<col_name> = 'string'", "<col_name> IS NOT NULL"] |             |
 
 
 ## Example

--- a/docs/row_transforms/order.md
+++ b/docs/row_transforms/order.md
@@ -6,10 +6,10 @@ Order a dataset by a given list of columns
 
 ## Parameters
 
-|   Argument   |    Type     |                                                       Description                                                       |
-| ------------ | ----------- | ----------------------------------------------------------------------------------------------------------------------- |
-| col_list     | column_list | List of columns by which to order the data source.                                                                      |
-| order_method | string      | ASC, for ascending, or DESC, for descending. This decides the order in which records will appear in the output dataset. |
+|   Argument   |    Type     |                                                       Description                                                       | Is Optional |
+| ------------ | ----------- | ----------------------------------------------------------------------------------------------------------------------- | ----------- |
+| col_list     | column_list | List of columns by which to order the data source.                                                                      |             |
+| order_method | string      | ASC, for ascending, or DESC, for descending. This decides the order in which records will appear in the output dataset. |             |
 
 
 ## Example

--- a/docs/table_transforms/aggregate.md
+++ b/docs/table_transforms/aggregate.md
@@ -6,10 +6,10 @@ Groups rows by the group_by items applying aggregations functions for the result
 
 ## Parameters
 
-|   Argument   |    Type     |                                                             Description                                                             |
-| ------------ | ----------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| group_by     | column_list | Columns to group by                                                                                                                 |
-| aggregations | agg_dict    | Aggregations to apply for other columns. Dict keys are column names, and values are a list of aggegations to apply for that column. |
+|   Argument   |    Type     |                                                             Description                                                             | Is Optional |
+| ------------ | ----------- | ----------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| group_by     | column_list | Columns to group by                                                                                                                 |             |
+| aggregations | agg_dict    | Aggregations to apply for other columns. Dict keys are column names, and values are a list of aggegations to apply for that column. |             |
 
 
 ## Example

--- a/docs/table_transforms/aggregate_string.md
+++ b/docs/table_transforms/aggregate_string.md
@@ -9,13 +9,13 @@ Uses a text separator to aggregate the string values together, and returns a sin
 
 ## Parameters
 
-|  Argument  |    Type     |                                                         Description                                                          |
-| ---------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| agg_column | column      | Column with string values to aggregate                                                                                       |
-| sep        | value       | Text separator to use when aggregating the strings, i.e. ', '.                                                               |
-| group_by   | column_list | Columns to group by when applying the aggregation.                                                                           |
-| distinct   | boolean     | If you want to collapse multiple rows of the same string value into a single distinct value, use TRUE. Otherwise, use FALSE. |
-| order      | value       | ASC or DESC, to set the alphabetical order of the agg_column when aggregating it                                             |
+|  Argument  |    Type     |                                                         Description                                                          | Is Optional |
+| ---------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| agg_column | column      | Column with string values to aggregate                                                                                       |             |
+| sep        | value       | Text separator to use when aggregating the strings, i.e. ', '.                                                               |             |
+| group_by   | column_list | Columns to group by when applying the aggregation.                                                                           |             |
+| distinct   | boolean     | If you want to collapse multiple rows of the same string value into a single distinct value, use TRUE. Otherwise, use FALSE. |             |
+| order      | value       | ASC or DESC, to set the alphabetical order of the agg_column when aggregating it                                             |             |
 
 
 ## Example

--- a/docs/table_transforms/datespine.md
+++ b/docs/table_transforms/datespine.md
@@ -16,12 +16,12 @@ FROM intervals
 
 ## Parameters
 
-|    Argument     |   Type    |                                                                           Description                                                                            |
-| --------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| date_col        | column    | The name of the column from the dataset that we'll be binning into some interval. This must be some sort of date or time column.                                 |
-| start_timestamp | timestamp | The timestamp to start calculating from; this will be included in the output set; this timestamp will have no timezone                                           |
-| end_timestamp   | timestamp | The timestamp to calculate to; this will be included in the output set; this timestamp will have no timezone                                                     |
-| interval_type   | date_part | the datepart to slice by. For interval types, see [this Snowflake doc.](https://docs.snowflake.com/en/sql-reference/data-types-datetime.html#interval-constants) |
+|    Argument     |   Type    |                                                                           Description                                                                            | Is Optional |
+| --------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| date_col        | column    | The name of the column from the dataset that we'll be binning into some interval. This must be some sort of date or time column.                                 |             |
+| start_timestamp | timestamp | The timestamp to start calculating from; this will be included in the output set; this timestamp will have no timezone                                           |             |
+| end_timestamp   | timestamp | The timestamp to calculate to; this will be included in the output set; this timestamp will have no timezone                                                     |             |
+| interval_type   | date_part | the datepart to slice by. For interval types, see [this Snowflake doc.](https://docs.snowflake.com/en/sql-reference/data-types-datetime.html#interval-constants) |             |
 
 
 ## Example

--- a/docs/table_transforms/dedupe.md
+++ b/docs/table_transforms/dedupe.md
@@ -6,11 +6,11 @@ Deduplicate a table based on a passed-in composite key. Once an order column and
 
 ## Parameters
 
-|   Argument   |    Type     |                                 Description                                  |
-| ------------ | ----------- | ---------------------------------------------------------------------------- |
-| natural_key  | column_list | Columns forming the grain at which to remove duplicates                      |
-| order_col    | column_list | Columns by which to order the result set, such that the first result is kept |
-| order_method | value       | Can be "desc" or "asc". Sets the order behavior for the chosen `order_col`.  |
+|   Argument   |    Type     |                                 Description                                  | Is Optional |
+| ------------ | ----------- | ---------------------------------------------------------------------------- | ----------- |
+| natural_key  | column_list | Columns forming the grain at which to remove duplicates                      |             |
+| order_col    | column_list | Columns by which to order the result set, such that the first result is kept |             |
+| order_method | value       | Can be "desc" or "asc". Sets the order behavior for the chosen `order_col`.  |             |
 
 
 ## Example

--- a/docs/table_transforms/join.md
+++ b/docs/table_transforms/join.md
@@ -6,11 +6,11 @@ Join a source table with another join table based on certain join keys between t
 
 ## Parameters
 
-|   Argument   |   Type    |                                                  Description                                                   |
-| ------------ | --------- | -------------------------------------------------------------------------------------------------------------- |
-| join_table   | table     | Dataset object to join with the source dataset.                                                                |
-| join_type    | join_type | 'LEFT','RIGHT', 'INNER', or None                                                                               |
-| join_columns | join_dict | Columns to use for the join. Keys are columns in the source_table and values are on columns in the join_table. |
+|   Argument   |   Type    |                                                  Description                                                   | Is Optional |
+| ------------ | --------- | -------------------------------------------------------------------------------------------------------------- | ----------- |
+| join_table   | table     | Dataset object to join with the source dataset.                                                                |             |
+| join_type    | join_type | 'LEFT','RIGHT', 'INNER', or None                                                                               |             |
+| join_columns | join_dict | Columns to use for the join. Keys are columns in the source_table and values are on columns in the join_table. |             |
 
 
 ## Example

--- a/docs/table_transforms/multi_join.md
+++ b/docs/table_transforms/multi_join.md
@@ -7,11 +7,11 @@ Join n number of datasets with the 'base' dataset, using a consistent join_type 
 
 ## Parameters
 
-|   Argument   |    Type     |                                              Description                                              |
-| ------------ | ----------- | ----------------------------------------------------------------------------------------------------- |
-| join_tables  | table_list  | Datasets to join with the source_table                                                                |
-| join_type    | join_type   | Type of join to run against the base dataset (either LEFT, RIGHT, or INNER)                           |
-| join_columns | column_list | Columns to join on. Can be one or more columns but must be named the same thing between all datasets. |
+|   Argument   |    Type     |                                              Description                                              | Is Optional |
+| ------------ | ----------- | ----------------------------------------------------------------------------------------------------- | ----------- |
+| join_tables  | table_list  | Datasets to join with the source_table                                                                |             |
+| join_type    | join_type   | Type of join to run against the base dataset (either LEFT, RIGHT, or INNER)                           |             |
+| join_columns | column_list | Columns to join on. Can be one or more columns but must be named the same thing between all datasets. |             |
 
 
 ## Example

--- a/docs/table_transforms/multi_union.md
+++ b/docs/table_transforms/multi_union.md
@@ -7,10 +7,10 @@ Union n number of datasets with the 'base' dataset, using a common list of colum
 
 ## Parameters
 
-|   Argument    |    Type     |                                                 Description                                                  |
-| ------------- | ----------- | ------------------------------------------------------------------------------------------------------------ |
-| union_tables  | table_list  | Datasets to union with the source_table                                                                      |
-| union_columns | column_list | Columns to union on. Can be one or more columns but must be named the same thing between all union datasets. |
+|   Argument    |    Type     |                                                 Description                                                  | Is Optional |
+| ------------- | ----------- | ------------------------------------------------------------------------------------------------------------ | ----------- |
+| union_tables  | table_list  | Datasets to union with the source_table                                                                      |             |
+| union_columns | column_list | Columns to union on. Can be one or more columns but must be named the same thing between all union datasets. |             |
 
 
 ## Example

--- a/docs/table_transforms/pivot.md
+++ b/docs/table_transforms/pivot.md
@@ -6,13 +6,13 @@ Transpose unique values in a single column to generate multiple columns, aggrega
 
 ## Parameters
 
-|   Argument   |    Type     |                                                         Description                                                         |
-| ------------ | ----------- | --------------------------------------------------------------------------------------------------------------------------- |
-| dimensions   | column_list | dimension columns after the pivot runs                                                                                      |
-| pivot_column | column      | column to pivot and aggregate                                                                                               |
-| value_column | column      | column with row values that will become columns                                                                             |
-| agg_method   | string      | method of aggregation (i.e. sum, avg, min, max, etc.)                                                                       |
-| list_of_vals | string_list | optional argument to override the dynamic lookup of all values in the value_column and only pivot a provided list of values |
+|   Argument   |    Type     |                                                         Description                                                         | Is Optional |
+| ------------ | ----------- | --------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| dimensions   | column_list | dimension columns after the pivot runs                                                                                      |             |
+| pivot_column | column      | column to pivot and aggregate                                                                                               |             |
+| value_column | column      | column with row values that will become columns                                                                             |             |
+| agg_method   | string      | method of aggregation (i.e. sum, avg, min, max, etc.)                                                                       |             |
+| list_of_vals | string_list | optional argument to override the dynamic lookup of all values in the value_column and only pivot a provided list of values | True        |
 
 
 ## Example

--- a/docs/table_transforms/simple_join.md
+++ b/docs/table_transforms/simple_join.md
@@ -7,11 +7,11 @@ Simple join between two datasets that uses a 'USING' clause. Returns all columns
 
 ## Parameters
 
-|   Argument   |    Type     |                                               Description                                                |
-| ------------ | ----------- | -------------------------------------------------------------------------------------------------------- |
-| join_table   | table       | Dataset object to join with the source_table                                                             |
-| join_type    | join_type   | LEFT, RIGHT, or INNER                                                                                    |
-| join_columns | column_list | Columns to join on. Can be one or more columns but must be named the same thing between the two objects. |
+|   Argument   |    Type     |                                               Description                                                | Is Optional |
+| ------------ | ----------- | -------------------------------------------------------------------------------------------------------- | ----------- |
+| join_table   | table       | Dataset object to join with the source_table                                                             |             |
+| join_type    | join_type   | LEFT, RIGHT, or INNER                                                                                    |             |
+| join_columns | column_list | Columns to join on. Can be one or more columns but must be named the same thing between the two objects. |             |
 
 
 ## Example

--- a/docs/table_transforms/union.md
+++ b/docs/table_transforms/union.md
@@ -6,10 +6,10 @@ Performs a SQL UNION or UNION ALL for the parent dataset, and another dataset. O
 
 ## Parameters
 
-| Argument  |  Type   |                                Description                                 |
-| --------- | ------- | -------------------------------------------------------------------------- |
-| dataset2  | table   | Dataset to Union/Union All with main dataset                               |
-| union_all | boolean | Set to True to performn a UNION ALL instead UNION between the two datasets |
+| Argument  |  Type   |                                Description                                 | Is Optional |
+| --------- | ------- | -------------------------------------------------------------------------- | ----------- |
+| dataset2  | table   | Dataset to Union/Union All with main dataset                               |             |
+| union_all | boolean | Set to True to performn a UNION ALL instead UNION between the two datasets | True        |
 
 
 ## Example

--- a/docs/table_transforms/unpivot.md
+++ b/docs/table_transforms/unpivot.md
@@ -6,11 +6,11 @@ Performs a UNPIVOT operation, rotating a table by transforming columns into rows
 
 ## Parameters
 
-|     Argument     |    Type     |                                                                                     Description                                                                                     |
-| ---------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| value_column     | string      | The name to assign to the generated column that will be populated with the values from the columns in the column list                                                               |
-| name_column      | string      | The name to assign to the generated column that will be populated with the names of the columns in the column list                                                                  |
-| column_list_vals | column_list | List of columns in the source table that will be narrowed into a single pivot column. The column names will populate name_column, and the column values will populate value_column. |
+|     Argument     |    Type     |                                                                                     Description                                                                                     | Is Optional |
+| ---------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| value_column     | string      | The name to assign to the generated column that will be populated with the values from the columns in the column list                                                               |             |
+| name_column      | string      | The name to assign to the generated column that will be populated with the names of the columns in the column list                                                                  |             |
+| column_list_vals | column_list | List of columns in the source table that will be narrowed into a single pivot column. The column names will populate name_column, and the column values will populate value_column. |             |
 
 
 ## Example

--- a/python/markdown.py
+++ b/python/markdown.py
@@ -39,7 +39,7 @@ def table(transform_args: Dict) -> str:
     transform args descriptions
     """
     writer = MarkdownTableWriter(
-        headers=["Argument", "Type", "Description"],
+        headers=["Argument", "Type", "Description", "Is Optional"],
         value_matrix=utils.get_table_values(transform_args),
         margin=1  # add a whitespace for both sides of each cell
     )

--- a/python/utils.py
+++ b/python/utils.py
@@ -121,7 +121,8 @@ def get_table_values(transform_args: Dict) -> List[List[str]]:
         row_data = [
             arg_name,
             arg_info['type'],
-            arg_info['description']
+            arg_info['description'],
+            arg_info.get('is_optional', '')
         ]
         all_data.append(row_data)
     return all_data

--- a/table_transforms/pivot/pivot.yaml
+++ b/table_transforms/pivot/pivot.yaml
@@ -16,6 +16,7 @@ arguments:
   list_of_vals:
     type: string_list
     description: optional argument to override the dynamic lookup of all values in the value_column and only pivot a provided list of values
+    is_optional: true
 example_code: |
   ds = rasgo.get.dataset(id)
 

--- a/table_transforms/union/union.yaml
+++ b/table_transforms/union/union.yaml
@@ -7,6 +7,7 @@ arguments:
   union_all:
     type: boolean
     description: Set to True to performn a UNION ALL instead UNION between the two datasets
+    is_optional: true
 example_code: |
   d1 = rasgo.get.dataset(dataset_id)
   d2 = rasgo.get.dataset(dataset_id_2)


### PR DESCRIPTION
This PR adds to the UDT YAML files a new flag `is_optional`, which is set to true for every optional UDT arg in this repo. it doesn't need to bet set in the YAML for UDT args which are required. 

We are also now adding a new column to the UDT doc that's generated indicating if a UDT arg is optional. 

**NOTE**: All the backend and Pyrasgo work is already in place/merged/live to store these in the `source_transform_argument` Postgres table in the column `is_optional`. Once merged with master the git workflow will update our prod DB ASAP.

## Important Ask for Reviewers
I had to manually go through each UDT jinja template/YAML file to check if the arg is optionally or not. I am pretty sure I got all of them but can you please
1. Make sure the ones I labeled as optional are in fact (pretty sure they are)
2. Let me know if I am missing any UDT args which are optional but weren't marked in this PR. 