### PR TITLE
dont make join_type optional

### DIFF
--- a/table_transforms/simple_join/simple_join.sql
+++ b/table_transforms/simple_join/simple_join.sql
@@ -1,6 +1,6 @@
 SELECT *
 FROM
 {{ source_table }}
-{{ join_type + ' ' if join_type else '' | upper }}JOIN
+{{ join_type | upper }} JOIN
 {{ join_table }}
 USING( {{join_columns | join(", ")}} )


### PR DESCRIPTION
make `join_type` required for `simple_transform`