### PR TITLE
fix bin docs

### DIFF
--- a/column_transforms/bin/bin.yaml
+++ b/column_transforms/bin/bin.yaml
@@ -13,7 +13,7 @@ arguments:
   type:
     type: string
     description: binning algorithm to use; must be `ntile` or `equalwidth`
-  bucket_count:
+  bin_count:
     type: int
     description: the number of equal-width bins to use
   column:
@@ -22,5 +22,5 @@ arguments:
 example_code: |
   ds = rasgo.get.dataset(id)
 
-  ds2 = ds.bin(binning_type='equalwidth', bucket_count=6, column='DAILY_HIGH_TEMP')
+  ds2 = ds.bin(type='equalwidth', bin_count=6, column='DAILY_HIGH_TEMP')
   ds2.preview()

--- a/docs/column_transforms/bin.md
+++ b/docs/column_transforms/bin.md
@@ -4,7 +4,7 @@
 
 This function will categorize or bin an input column such that for N bins, an output column is created with values `[1-N]` where each value represents some bin.
 
-This transformation supports two binning methods (called "binning_type" in the arguments): `ntile` and `equalwidth`.
+This transformation supports two binning methods (called "type" in the arguments): `ntile` and `equalwidth`.
 
 ## N-tile
 When using `ntile` binnint the boundaries for the bins are calculated such that each bin will receive an almost equal number of elements. It will create a new column called {{column}}_{{bin_count}}_NTB. This ensures that multiple equal-weight binning operations will produce column names that don't overlap.
@@ -18,7 +18,7 @@ The `equalwidth` method will calculate the boundaries of the bins such that they
 |   Argument   |  Type  |                        Description                        | Is Optional |
 | ------------ | ------ | --------------------------------------------------------- | ----------- |
 | type         | string | binning algorithm to use; must be `ntile` or `equalwidth` |             |
-| bucket_count | int    | the number of equal-width bins to use                     |             |
+| bin_count | int    | the number of equal-width bins to use                     |             |
 | column       | column | which column to bucket                                    |             |
 
 
@@ -27,7 +27,7 @@ The `equalwidth` method will calculate the boundaries of the bins such that they
 ```python
 ds = rasgo.get.dataset(id)
 
-ds2 = ds.bin(binning_type='equalwidth', bucket_count=6, column='DAILY_HIGH_TEMP')
+ds2 = ds.bin(type='equalwidth', bin_count=6, column='DAILY_HIGH_TEMP')
 ds2.preview()
 ```
 

--- a/docs/column_transforms/bin.md
+++ b/docs/column_transforms/bin.md
@@ -4,7 +4,7 @@
 
 This function will categorize or bin an input column such that for N bins, an output column is created with values `[1-N]` where each value represents some bin.
 
-This transformation supports two binning methods (called "type" in the arguments): `ntile` and `equalwidth`.
+This transformation supports two binning methods (called "binning_type" in the arguments): `ntile` and `equalwidth`.
 
 ## N-tile
 When using `ntile` binnint the boundaries for the bins are calculated such that each bin will receive an almost equal number of elements. It will create a new column called {{column}}_{{bin_count}}_NTB. This ensures that multiple equal-weight binning operations will produce column names that don't overlap.
@@ -15,11 +15,11 @@ The `equalwidth` method will calculate the boundaries of the bins such that they
 
 ## Parameters
 
-|   Argument   |  Type  |                        Description                        | Is Optional |
-| ------------ | ------ | --------------------------------------------------------- | ----------- |
-| type         | string | binning algorithm to use; must be `ntile` or `equalwidth` |             |
+| Argument  |  Type  |                        Description                        | Is Optional |
+| --------- | ------ | --------------------------------------------------------- | ----------- |
+| type      | string | binning algorithm to use; must be `ntile` or `equalwidth` |             |
 | bin_count | int    | the number of equal-width bins to use                     |             |
-| column       | column | which column to bucket                                    |             |
+| column    | column | which column to bucket                                    |             |
 
 
 ## Example
@@ -29,6 +29,7 @@ ds = rasgo.get.dataset(id)
 
 ds2 = ds.bin(type='equalwidth', bin_count=6, column='DAILY_HIGH_TEMP')
 ds2.preview()
+
 ```
 
 ## Source Code


### PR DESCRIPTION
Bug fix courtesy of the Professor.
Docs are out of sync with the args for the bin transform. This PR changes docs to match the jinja args.