### PR TITLE
Does this have side effects?

### DIFF
--- a/column_transforms/cast/cast.yaml
+++ b/column_transforms/cast/cast.yaml
@@ -3,7 +3,7 @@ description: |
   Cast selected columns to a new type
 arguments:
   casts:
-    type: column_value_dict
+    type: cast_value_dict
     description: A dict where the keys are columns and the values are the new type to cast them to.
 example_code: |
   ds = rasgo.get.dataset(id)

--- a/docs/column_transforms/cast.md
+++ b/docs/column_transforms/cast.md
@@ -7,9 +7,9 @@ Cast selected columns to a new type
 
 ## Parameters
 
-| Argument |       Type        |                                    Description                                     | Is Optional |
-| -------- | ----------------- | ---------------------------------------------------------------------------------- | ----------- |
-| casts    | cast_value_dict   | A dict where the keys are columns and the values are the new type to cast them to. |             |
+| Argument |      Type       |                                    Description                                     | Is Optional |
+| -------- | --------------- | ---------------------------------------------------------------------------------- | ----------- |
+| casts    | cast_value_dict | A dict where the keys are columns and the values are the new type to cast them to. |             |
 
 
 ## Example

--- a/docs/column_transforms/cast.md
+++ b/docs/column_transforms/cast.md
@@ -9,7 +9,7 @@ Cast selected columns to a new type
 
 | Argument |       Type        |                                    Description                                     | Is Optional |
 | -------- | ----------------- | ---------------------------------------------------------------------------------- | ----------- |
-| casts    | column_value_dict | A dict where the keys are columns and the values are the new type to cast them to. |             |
+| casts    | cast_value_dict   | A dict where the keys are columns and the values are the new type to cast them to. |             |
 
 
 ## Example


### PR DESCRIPTION
I have a UI PR open that updates the arguments we display for a cast transform in the UI. I built it with the assumption that I could change the argument passed in for cast from "column_value_dict" to "cast_value_dict". Also, I made the assumption that pyrasgo could handle this change because it would only change how the transform was shown in the SDK, and not change anything about how it was stored.

I'm raising this PR to check these assumptions. Let me know your thoughts/if I'm wrong

Here's the UI PR: https://github.com/rasgointelligence/RasgoUI/pull/206