### PR TITLE
Support a couple of aliases

### DIFF
--- a/column_transforms/concat/concat.sql
+++ b/column_transforms/concat/concat.sql
@@ -1,8 +1,14 @@
+{%- if name is defined -%}
+    {%- set alias = cleanse_name(name) -%}
+{%- else -%}
+    {%- set alias = 'CONCAT_'~ cleanse_name(concat_list | join('_')) -%}
+{%- endif -%}
+
 SELECT
 *
 , CONCAT(
     {%- for obj in concat_list %}
     {{obj}}{{ ", " if not loop.last else "" }}
     {%- endfor %}
-) AS CONCAT_{%- for obj in concat_list %}{{cleanse_name(obj)}}{%- endfor %}
+) AS {{ alias }}
 FROM {{ source_table }}

--- a/column_transforms/concat/concat.yaml
+++ b/column_transforms/concat/concat.yaml
@@ -7,8 +7,14 @@ arguments:
   concat_list:
     type: mixed_list
     description: A list representing each new column to be created.
+  name:
+    type: value
+    is_optional: true
+    description: A name for the new column created by the concatenation.
 example_code: |
-  ds = rasgo.get.dataset(id)
+  product = rasgo.get.dataset(75)
+  ds2 = product.concat(
+    concat_list=['PRODUCTKEY', 'PRODUCTALTERNATEKEY', "' hybridkey'"],
+    name='Hybrid Key')
 
-  ds2 = ds.concat(concat_list=["DS_WEATHER_ICON", "'some_str'", "'_5'"])
   ds2.preview()

--- a/column_transforms/math/math.sql
+++ b/column_transforms/math/math.sql
@@ -1,6 +1,23 @@
+{%- if names -%}
+    {%- if names|length != math_ops|length -%}
+
+Error: Provide a new column alias for each math operation
+
+    {%- elif names|length == math_ops|length -%}
+
+SELECT *
+{%- for math_op in math_ops %}
+    , {{math_op}} as {{cleanse_name(names[loop.index-1])}}
+{%- endfor %}
+FROM {{source_table}}
+
+    {%- endif -%}
+{%- else -%}
+
 SELECT *
 {%- for math_op in math_ops %}
     , {{math_op}} as {{cleanse_name(math_op)}}
 {%- endfor %}
-
 FROM {{source_table}}
+
+{%- endif -%}

--- a/column_transforms/math/math.yaml
+++ b/column_transforms/math/math.yaml
@@ -3,8 +3,8 @@ description: |
   Calculate one or more new columns using math functions.
 
   Examples of Valid Functions:
-    [Basic Arithmetic](https://docs.snowflake.com/en/sql-reference/operators-arithmetic.html#list-of-arithmetic-operators)
-    [Numeric Functions](https://docs.snowflake.com/en/sql-reference/functions-numeric.html)
+    - [Basic Arithmetic](https://docs.snowflake.com/en/sql-reference/operators-arithmetic.html#list-of-arithmetic-operators)
+    - [Numeric Functions](https://docs.snowflake.com/en/sql-reference/functions-numeric.html)
 arguments:
   math_ops:
     type: math_list

--- a/column_transforms/math/math.yaml
+++ b/column_transforms/math/math.yaml
@@ -1,11 +1,23 @@
 name: math
-description: Create one or more new columns 
+description: |
+  Calculate one or more new columns using math functions.
+
+  Examples of Valid Functions:
+    [Basic Arithmetic](https://docs.snowflake.com/en/sql-reference/operators-arithmetic.html#list-of-arithmetic-operators)
+    [Numeric Functions](https://docs.snowflake.com/en/sql-reference/functions-numeric.html)
 arguments:
   math_ops:
     type: math_list
-    description: List of math operations to generate new columns. Ex. ["<col_name> + 5", "<col_name> / 100"]
+    description: List of math operations to generate new columns. For example, ["AGE_COLUMN + 5", "WEIGHT_COLUMN / 100"]
+  names:
+    type: value_list
+    is_optional: true
+    description: To alias the new columns, provide a list of column names matching the number of math operations.
 example_code: |
-  ds = rasgo.get.dataset(id)
+  internet_sales = rasgo.get.dataset(74)
 
-  ds2 = ds.math(math_ops=['MONTH * 12', 'YEAR - 2000'])
+  ds2 = internet_sales.math(
+      math_ops=['SALESAMOUNT * 10', 'SALESAMOUNT - TAXAMT'],
+      names=['Sales10', 'SalesNet'])
+
   ds2.preview()

--- a/docs/column_transforms/concat.md
+++ b/docs/column_transforms/concat.md
@@ -9,19 +9,21 @@ Pass in a list named "concat_list", containing the names of the columns and the 
 
 ## Parameters
 
-|  Argument   |    Type    |                    Description                     | Is Optional |
-| ----------- | ---------- | -------------------------------------------------- | ----------- |
-| concat_list | mixed_list | A list representing each new column to be created. |             |
+|  Argument   |    Type    |                       Description                       | Is Optional |
+| ----------- | ---------- | ------------------------------------------------------- | ----------- |
+| concat_list | mixed_list | A list representing each new column to be created.      |             |
+| name        | value      | A name for the new column created by the concatenation. | True        |
 
 
 ## Example
 
 ```python
-ds = rasgo.get.dataset(id)
+product = rasgo.get.dataset(75)
+ds2 = product.concat(
+  concat_list=['PRODUCTKEY', 'PRODUCTALTERNATEKEY', "' hybridkey'"],
+  name='Hybrid Key')
 
-ds2 = ds.concat(concat_list=["DS_WEATHER_ICON", "'some_str'", "'_5'"])
 ds2.preview()
-
 ```
 
 ## Source Code

--- a/docs/column_transforms/math.md
+++ b/docs/column_transforms/math.md
@@ -5,8 +5,8 @@
 Calculate one or more new columns using math functions.
 
 Examples of Valid Functions:
-  [Basic Arithmetic](https://docs.snowflake.com/en/sql-reference/operators-arithmetic.html#list-of-arithmetic-operators)
-  [Numeric Functions](https://docs.snowflake.com/en/sql-reference/functions-numeric.html)
+  - [Basic Arithmetic](https://docs.snowflake.com/en/sql-reference/operators-arithmetic.html#list-of-arithmetic-operators)
+  - [Numeric Functions](https://docs.snowflake.com/en/sql-reference/functions-numeric.html)
 
 
 ## Parameters

--- a/docs/column_transforms/math.md
+++ b/docs/column_transforms/math.md
@@ -2,21 +2,30 @@
 
 # math
 
-Create one or more new columns
+Calculate one or more new columns using math functions.
+
+Examples of Valid Functions:
+  [Basic Arithmetic](https://docs.snowflake.com/en/sql-reference/operators-arithmetic.html#list-of-arithmetic-operators)
+  [Numeric Functions](https://docs.snowflake.com/en/sql-reference/functions-numeric.html)
+
 
 ## Parameters
 
-| Argument |   Type    |                                         Description                                         | Is Optional |
-| -------- | --------- | ------------------------------------------------------------------------------------------- | ----------- |
-| math_ops | math_list | List of math operations to generate new columns. Ex. ["<col_name> + 5", "<col_name> / 100"] |             |
+| Argument |    Type    |                                               Description                                               | Is Optional |
+| -------- | ---------- | ------------------------------------------------------------------------------------------------------- | ----------- |
+| math_ops | math_list  | List of math operations to generate new columns. For example, ["AGE_COLUMN + 5", "WEIGHT_COLUMN / 100"] |             |
+| names    | value_list | To alias the new columns, provide a list of column names matching the number of math operations.        | True        |
 
 
 ## Example
 
 ```python
-ds = rasgo.get.dataset(id)
+internet_sales = rasgo.get.dataset(74)
 
-ds2 = ds.math(math_ops=['MONTH * 12', 'YEAR - 2000'])
+ds2 = internet_sales.math(
+    math_ops=['SALESAMOUNT * 10', 'SALESAMOUNT - TAXAMT'],
+    names=['Sales10', 'SalesNet'])
+
 ds2.preview()
 ```
 


### PR DESCRIPTION
Adding optional ways to pass new column aliases to math and concat transforms. Likely will want to replicate this on some other transforms in the future.