### PR TITLE
Fix join aliasing

### DIFF
--- a/docs/table_transforms/join.md
+++ b/docs/table_transforms/join.md
@@ -2,31 +2,32 @@
 
 # join
 
-Join a source table with another join table based on certain join keys between table. **NOTE**: For columns in the Join table with the same name in the source table, only the columns from the join table will be included in the output. 
+Join a dataset with another dataset, by matching on one or more columns between the two tables.
+
+For columns that share the same name in both tables, the columns in the join_table will be aliased as "{join_table}_{columnname}".
+
 
 ## Parameters
 
 |   Argument   |   Type    |                                                  Description                                                   | Is Optional |
 | ------------ | --------- | -------------------------------------------------------------------------------------------------------------- | ----------- |
 | join_table   | table     | Dataset object to join with the source dataset.                                                                |             |
-| join_type    | join_type | 'LEFT','RIGHT', 'INNER', or None                                                                               |             |
+| join_type    | join_type | LEFT, RIGHT, or INNER                                                                                          |             |
 | join_columns | join_dict | Columns to use for the join. Keys are columns in the source_table and values are on columns in the join_table. |             |
 
 
 ## Example
 
 ```python
-source_ds = rasgo.get.dataset(101)
-join_ds = rasgo.get.dataset(201)
+internet_sales = rasgo.get.dataset(74)
+product = rasgo.get.dataset(75)
 
-source_ds.join(
-  join_table=join_ds,
-  join_type='LEFT',
-  join_columns={
-    'MONTH':'MONTH',
-    'TICKER':'TICKER'
-  }
-).preview()
+ds2 = internet_sales.join(
+  join_table=product,
+  join_columns={'PRODUCTKEY':'PRODUCTKEY'},
+  join_type='LEFT')
+
+ds2.preview()
 ```
 
 ## Source Code

--- a/table_transforms/join/join.sql
+++ b/table_transforms/join/join.sql
@@ -36,6 +36,8 @@ SELECT
 {%- for join_col in join_col_names -%}
     {%- if join_col not in source_col_names -%}
         , t2.{{ join_col }}
+    {%- elif join_col in source_col_names -%}
+        , t2.{{ join_col }} as {{ cleanse_name(join_table_name)~'_'~join_col }}
     {% endif %}
 {%- endfor %}
 FROM {{ source_table }} as t1

--- a/table_transforms/join/join.yaml
+++ b/table_transforms/join/join.yaml
@@ -1,24 +1,25 @@
 name: join
-description:  "Join a source table with another join table based on certain join keys between table. **NOTE**: For columns in the Join table with the same name in the source table, only the columns from the join table will be included in the output. "
+description: |
+  Join a dataset with another dataset, by matching on one or more columns between the two tables.
+
+  For columns that share the same name in both tables, the columns in the join_table will be aliased as "{join_table}_{columnname}".
 arguments:
   join_table:
     type: table
     description: Dataset object to join with the source dataset.
   join_type:
     type: join_type
-    description: "'LEFT','RIGHT', 'INNER', or None"
+    description: LEFT, RIGHT, or INNER
   join_columns:
     type: join_dict
     description: Columns to use for the join. Keys are columns in the source_table and values are on columns in the join_table.
 example_code: |
-  source_ds = rasgo.get.dataset(101)
-  join_ds = rasgo.get.dataset(201)
+  internet_sales = rasgo.get.dataset(74)
+  product = rasgo.get.dataset(75)
 
-  source_ds.join(
-    join_table=join_ds,
-    join_type='LEFT',
-    join_columns={
-      'MONTH':'MONTH',
-      'TICKER':'TICKER'
-    }
-  ).preview()
+  ds2 = internet_sales.join(
+    join_table=product,
+    join_columns={'PRODUCTKEY':'PRODUCTKEY'},
+    join_type='LEFT')
+
+  ds2.preview()


### PR DESCRIPTION
this PR changes how 'join' handles columns that have the same name in both tables