### PR TITLE
Fancy datespine

### DIFF
--- a/docs/table_transforms/datespine.md
+++ b/docs/table_transforms/datespine.md
@@ -4,8 +4,11 @@
 
 This transform generates a date spine for your date index, which can replace your date index column for modeling.
 
-All intervals are considered to be start-inclusive and end-exclusive, or `(start, end]`. The join with the date spine will be an outer join such that all intervals are present and all data that does not fall into one of those intervals is excluded. It's essentially:
+All intervals are considered to be start-inclusive and end-exclusive, or `[start, end]`. 
+The join with the date spine will be an outer join such that all intervals are present 
+and all data that does not fall into one of those intervals is excluded. 
 
+It's essentially:
 ```
 SELECT user_table.*, intervals.*
 FROM intervals
@@ -16,26 +19,27 @@ FROM intervals
 
 ## Parameters
 
-|    Argument     |   Type    |                                                                           Description                                                                            | Is Optional |
-| --------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| date_col        | column    | The name of the column from the dataset that we'll be binning into some interval. This must be some sort of date or time column.                                 |             |
-| start_timestamp | timestamp | The timestamp to start calculating from; this will be included in the output set; this timestamp will have no timezone                                           |             |
-| end_timestamp   | timestamp | The timestamp to calculate to; this will be included in the output set; this timestamp will have no timezone                                                     |             |
-| interval_type   | date_part | the datepart to slice by. For interval types, see [this Snowflake doc.](https://docs.snowflake.com/en/sql-reference/data-types-datetime.html#interval-constants) |             |
+|    Argument     |   Type    |                                                                                    Description                                                                                     | Is Optional |
+| --------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| date_col        | column    | The column used to create intervals. This must be a datetime column.                                                                                                               |             |
+| start_timestamp | timestamp | The timestamp to start calculating from;  this will be included in the output set; this timestamp will have no timezone                                                            |             |
+| end_timestamp   | timestamp | The timestamp to calculate to;  this will be included in the output set; this timestamp will have no timezone                                                                      |             |
+| interval_type   | date_part | A valid SQL datepart to slice the date_col. For interval types, see [this Snowflake doc.](https://docs.snowflake.com/en/sql-reference/data-types-datetime.html#interval-constants) |             |
 
 
 ## Example
 
 ```python
-ds = rasgo.get.dataset(id)
+ds = rasgo.get.dataset(74)
 
 ds2 = ds.datespine(
-    date_col='event_dt',
+    date_col='ORDERDATE',
     start_timestamp='2017-01-01',
     end_timestamp='2020-01-01',
     interval_type='month'
 )
 ds2.preview()
+
 ```
 
 ## Source Code

--- a/docs/table_transforms/datespine_groups.md
+++ b/docs/table_transforms/datespine_groups.md
@@ -1,0 +1,66 @@
+
+
+# datespine_series
+
+This transform generates a date spine for your date index, which can replace your date index column for modeling.
+
+All intervals are considered to be start-inclusive and end-exclusive, or `[start, end]`. 
+The join with the date spine will be an outer join such that all intervals are present 
+and all data that does not fall into one of those intervals is excluded. 
+
+It's essentially:
+```
+SELECT user_table.*, intervals.*
+FROM intervals
+  LEFT JOIN user_table
+  ON ...
+```
+
+
+## Parameters
+
+|    Argument     |    Type     |                                                                                    Description                                                                                     | Is Optional |
+| --------------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| group_by        | column_list | The column(s) used to partition you data into groups. A datespine will be calculated for each group.                                                                               |             |
+| date_col        | column      | The column used to create intervals. This must be a datetime column.                                                                                                               |             |
+| group_bounds    | value       | values [global, local] ...                                                                                                                                                         |             |
+| interval_type   | date_part   | A valid SQL datepart to slice the date_col. For interval types, see [this Snowflake doc.](https://docs.snowflake.com/en/sql-reference/data-types-datetime.html#interval-constants) |             |
+| start_timestamp | timestamp   | The timestamp to start calculating from;  this will be included in the output set; this timestamp will have no timezone                                                            |             |
+| end_timestamp   | timestamp   | The timestamp to calculate to;  this will be included in the output set; this timestamp will have no timezone                                                                      |             |
+
+
+## Example
+
+```python
+ds = rasgo.get.dataset(74)
+
+# Usage 1: Local datespines - will return a datespine per group with 
+# min/max values within the group
+ds2 = ds.datespine_groups(
+    group_by=['PRODUCTKEY'],
+    date_col='ORDERDATE',
+    group_bounds='local',
+    interval_type='day',
+    start_timestamp='2010-12-29',
+    end_timestamp='2014-01-28' 
+)
+ds2.preview()
+
+# Usage 2: Global datespines - will return a datespine per group with 
+# min/max values set to the global min/max
+ds2 = ds.datespine_groups(
+    group_by=['PRODUCTKEY'],
+    date_col='ORDERDATE',
+    group_bounds='global',
+    interval_type='day',
+    start_timestamp='2010-12-29',
+    end_timestamp='2014-01-28' 
+)
+ds2.preview()
+
+```
+
+## Source Code
+
+{% embed url="https://github.com/rasgointelligence/RasgoUDTs/blob/main/table_transforms/datespine_groups/datespine_groups.sql" %}
+

--- a/table_transforms/datespine/datespine.yaml
+++ b/table_transforms/datespine/datespine.yaml
@@ -2,8 +2,11 @@ name: datespine
 description: |
   This transform generates a date spine for your date index, which can replace your date index column for modeling.
   
-  All intervals are considered to be start-inclusive and end-exclusive, or `(start, end]`. The join with the date spine will be an outer join such that all intervals are present and all data that does not fall into one of those intervals is excluded. It's essentially:
-
+  All intervals are considered to be start-inclusive and end-exclusive, or `[start, end]`. 
+  The join with the date spine will be an outer join such that all intervals are present 
+  and all data that does not fall into one of those intervals is excluded. 
+  
+  It's essentially:
   ```
   SELECT user_table.*, intervals.*
   FROM intervals
@@ -13,21 +16,26 @@ description: |
 arguments:
   date_col:
     type: column
-    description: The name of the column from the dataset that we'll be binning into some interval. This must be some sort of date or time column.
+    description: The column used to create intervals. This must be a datetime column.
   start_timestamp:
     type: timestamp
-    description: The timestamp to start calculating from; this will be included in the output set; this timestamp will have no timezone
+    description: |
+      The timestamp to start calculating from; 
+      this will be included in the output set; this timestamp will have no timezone
   end_timestamp:
     type: timestamp
-    description: The timestamp to calculate to; this will be included in the output set; this timestamp will have no timezone
+    description: | 
+      The timestamp to calculate to; 
+      this will be included in the output set; this timestamp will have no timezone
   interval_type:
     type: date_part
-    description: the datepart to slice by. For interval types, see [this Snowflake doc.](https://docs.snowflake.com/en/sql-reference/data-types-datetime.html#interval-constants)
+    description: A valid SQL datepart to slice the date_col. 
+      For interval types, see [this Snowflake doc.](https://docs.snowflake.com/en/sql-reference/data-types-datetime.html#interval-constants)
 example_code: |
-  ds = rasgo.get.dataset(id)
+  ds = rasgo.get.dataset(74)
 
   ds2 = ds.datespine(
-      date_col='event_dt',
+      date_col='ORDERDATE',
       start_timestamp='2017-01-01',
       end_timestamp='2020-01-01',
       interval_type='month'

--- a/table_transforms/datespine_groups/datespine_groups.sql
+++ b/table_transforms/datespine_groups/datespine_groups.sql
@@ -1,0 +1,57 @@
+{% set row_count_query %}
+select datediff('{{ interval_type }}', '{{ start_timestamp }}'::timestamp_ntz, '{{ end_timestamp }}'::timestamp_ntz)
+{% endset %}
+{% set row_count_query_results = run_query(row_count_query) %}
+{% set row_count = row_count_query_results[row_count_query_results.columns[0]][0] %}
+
+WITH GLOBAL_SPINE AS (
+  SELECT
+    ROW_NUMBER() OVER (ORDER BY NULL) as INTERVAL_ID,
+    DATEADD('{{ interval_type }}', (INTERVAL_ID - 1), '{{ start_timestamp }}'::timestamp_ntz) as SPINE_START,
+    DATEADD('{{ interval_type }}', INTERVAL_ID, '{{ start_timestamp }}'::timestamp_ntz) as SPINE_END
+  FROM TABLE (GENERATOR(ROWCOUNT => {{ row_count }}))
+), 
+GROUPS AS (
+  SELECT 
+    {% for col in group_by -%}
+    {{ col }},
+    {%- endfor %}
+    MIN({{ date_col }}) AS LOCAL_START, 
+    MAX({{ date_col }}) AS LOCAL_END
+  FROM {{ source_table }}
+  GROUP BY 
+    {% for col in group_by -%}
+    {{ col }}{{ ', ' if not loop.last else ' ' }}
+    {%- endfor %}
+), 
+GROUP_SPINE AS (
+  SELECT 
+    {% for col in group_by -%}
+    {{ col }},
+    {%- endfor %}
+    SPINE_START AS GROUP_START, 
+    SPINE_END AS GROUP_END
+  FROM GROUPS G
+  CROSS JOIN LATERAL (
+    SELECT
+      SPINE_START, SPINE_END
+    FROM GLOBAL_SPINE S
+    {% if group_bounds == 'local' %}
+    WHERE S.SPINE_START BETWEEN G.LOCAL_START AND G.LOCAL_END
+    {% endif %}
+  )
+)
+
+SELECT 
+  {% for col in group_by -%}
+  G.{{ col }} AS GROUP_BY_{{ col }},
+  {%- endfor %}
+  GROUP_START, 
+  GROUP_END,
+  T.*
+FROM GROUP_SPINE G
+LEFT JOIN {{ source_table }} T
+  ON T.ORDERDATE BETWEEN G.GROUP_START AND G.GROUP_END
+  {% for col in group_by -%}
+     AND G.{{ col }} = T.{{ col }}
+  {%- endfor %}

--- a/table_transforms/datespine_groups/datespine_groups.yaml
+++ b/table_transforms/datespine_groups/datespine_groups.yaml
@@ -1,0 +1,66 @@
+name: datespine_series
+description: |
+  This transform generates a date spine for your date index, which can replace your date index column for modeling.
+  
+  All intervals are considered to be start-inclusive and end-exclusive, or `[start, end]`. 
+  The join with the date spine will be an outer join such that all intervals are present 
+  and all data that does not fall into one of those intervals is excluded. 
+  
+  It's essentially:
+  ```
+  SELECT user_table.*, intervals.*
+  FROM intervals
+    LEFT JOIN user_table
+    ON ...
+  ```
+arguments:
+  group_by:
+    type: column_list
+    description: The column(s) used to partition you data into groups.
+      A datespine will be calculated for each group.
+  date_col:
+    type: column
+    description: The column used to create intervals. This must be a datetime column.
+  group_bounds:
+    type: value
+    description: values [global, local] ...
+  interval_type:
+    type: date_part
+    description: A valid SQL datepart to slice the date_col. 
+      For interval types, see [this Snowflake doc.](https://docs.snowflake.com/en/sql-reference/data-types-datetime.html#interval-constants)
+  start_timestamp:
+    type: timestamp
+    description: |
+      The timestamp to start calculating from; 
+      this will be included in the output set; this timestamp will have no timezone
+  end_timestamp:
+    type: timestamp
+    description: | 
+      The timestamp to calculate to; 
+      this will be included in the output set; this timestamp will have no timezone
+example_code: |
+  ds = rasgo.get.dataset(74)
+
+  # Usage 1: Local datespines - will return a datespine per group with 
+  # min/max values within the group
+  ds2 = ds.datespine_groups(
+      group_by=['PRODUCTKEY'],
+      date_col='ORDERDATE',
+      group_bounds='local',
+      interval_type='day',
+      start_timestamp='2010-12-29',
+      end_timestamp='2014-01-28' 
+  )
+  ds2.preview()
+
+  # Usage 2: Global datespines - will return a datespine per group with 
+  # min/max values set to the global min/max
+  ds2 = ds.datespine_groups(
+      group_by=['PRODUCTKEY'],
+      date_col='ORDERDATE',
+      group_bounds='global',
+      interval_type='day',
+      start_timestamp='2010-12-29',
+      end_timestamp='2014-01-28' 
+  )
+  ds2.preview()


### PR DESCRIPTION
This is the first bullet point in [RAS-2546](https://linear.app/rasgoml/issue/RAS-2546/3-timeseries-prep-transforms)

It allows users to apply a datespine to groups within a table, instead of to the entire table.
