### PR TITLE
Changes to support pypi packaging

### DIFF
--- a/column_transforms/drop_columns/drop_columns.sql
+++ b/column_transforms/drop_columns/drop_columns.sql
@@ -3,14 +3,7 @@ Jinja Macro to generate a query that would get all
 the columns in a table by fqtn
 #}
 {%- macro get_source_col_names(source_table_fqtn=None) -%}
-    {%- set database, schema, table = '', '', '' -%}
-    {%- if source_table_fqtn -%}
-        {%- set database, schema, table = source_table_fqtn.split('.') -%}
-    {%- endif -%}
-        SELECT COLUMN_NAME FROM {{ database }}.information_schema.columns
-        WHERE TABLE_CATALOG = '{{ database|upper }}'
-        AND   TABLE_SCHEMA = '{{ schema|upper }}'
-        AND   TABLE_NAME = '{{ table|upper }}'
+    select top 0 * from {{ source_table_fqtn }}
 {%- endmacro -%}
 
 {% if include_cols and exclude_cols is defined %}
@@ -28,7 +21,7 @@ FROM {{source_table}}
 {%- if exclude_cols is defined -%}
 {# Get all Columns in Source Table #}
 {%- set col_names_source_df = run_query(get_source_col_names(source_table_fqtn=source_table)) -%}
-{%- set source_col_names = col_names_source_df['COLUMN_NAME'].to_list() -%}
+{%- set source_col_names = col_names_source_df.columns -%}
 {%- set new_columns = source_col_names | reject('in', exclude_cols) -%}
 
 

--- a/column_transforms/impute/impute.sql
+++ b/column_transforms/impute/impute.sql
@@ -3,12 +3,7 @@ Jinja Macro to generate a query that would get all
 the columns in a table by fqtn
 #}
 {%- macro get_source_col_names(source_table_fqtn) -%}
-    {%- set database, schema, table = '', '', '' -%}
-    {%- set database, schema, table = source_table_fqtn.split('.') -%}
-    SELECT COLUMN_NAME FROM {{ database }}.information_schema.columns
-    WHERE TABLE_CATALOG = '{{ database|upper }}'
-    AND   TABLE_SCHEMA = '{{ schema|upper }}'
-    AND   TABLE_NAME = '{{ table|upper }}'
+    select top 0 * from {{ source_table_fqtn }}
 {%- endmacro -%}
 
 {# 
@@ -44,7 +39,7 @@ else it will perform that impuattion stagety on column
 
 {# Get all Columns in Source Table #}
 {%- set col_names_source_df = run_query(get_source_col_names(source_table_fqtn=source_table)) -%}
-{%- set source_col_names = col_names_source_df['COLUMN_NAME'].to_list() -%}
+{%- set source_col_names = col_names_source_df.columns -%}
 
 SELECT
 {%- for col in source_col_names -%}
@@ -58,4 +53,3 @@ SELECT
     {%- endif -%}
 {%- endfor %}
 FROM {{source_table}}
-

--- a/column_transforms/rename/rename.sql
+++ b/column_transforms/rename/rename.sql
@@ -3,20 +3,13 @@ Jinja Macro to generate a query that would get all
 the columns in a table by fqtn
 #}
 {%- macro get_source_col_names(source_table_fqtn=None) -%}
-    {%- set database, schema, table = '', '', '' -%}
-    {%- if source_table_fqtn -%}
-        {%- set database, schema, table = source_table_fqtn.split('.') -%}
-    {%- endif -%}
-        SELECT COLUMN_NAME FROM {{ database }}.information_schema.columns
-        WHERE TABLE_CATALOG = '{{ database|upper }}'
-        AND   TABLE_SCHEMA = '{{ schema|upper }}'
-        AND   TABLE_NAME = '{{ table|upper }}'
+    select top 0 * from {{ source_table_fqtn }}
 {%- endmacro -%}
 
 
 {# Get all Columns in Source Table #}
 {%- set col_names_source_df = run_query(get_source_col_names(source_table_fqtn=source_table)) -%}
-{%- set source_col_names = col_names_source_df['COLUMN_NAME'].to_list() -%}
+{%- set source_col_names = col_names_source_df.columns -%}
 
 SELECT
 {%- for target_col, new_name in renames.items() %}

--- a/table_transforms/describe/describe.sql
+++ b/table_transforms/describe/describe.sql
@@ -1,10 +1,16 @@
 {%- macro get_col_names_types(source_table_fqtn=None) -%}
-    {%- set database, schema, table = source_table_fqtn.split('.') -%}
+    {%- if source_table_fqtn.count('.') == 2 -%}
+      {%- set database, schema, table = source_table_fqtn.split('.') -%}
         SELECT COLUMN_NAME, DATA_TYPE
         FROM {{ database }}.information_schema.columns
         WHERE TABLE_CATALOG = '{{ database|upper }}'
         AND   TABLE_SCHEMA = '{{ schema|upper }}'
         AND   TABLE_NAME = '{{ table|upper }}'
+    {%- else -%}
+        SELECT COLUMN_NAME, DATA_TYPE
+        FROM information_schema.columns
+        WHERE TABLE_NAME = '{{ source_table_fqtn|upper }}'
+    {%- endif -%}
 {%- endmacro -%}
 {# Get all Columns in Source Table #}
 {%- set names_types_df = run_query(get_col_names_types(source_table_fqtn=source_table)) -%}

--- a/table_transforms/join/join.sql
+++ b/table_transforms/join/join.sql
@@ -3,14 +3,7 @@ Jinja Macro to generate a query that would get all
 the columns in a table by fqtn
 #}
 {%- macro get_source_col_names(source_table_fqtn=None) -%}
-    {%- set database, schema, table = '', '', '' -%}
-    {%- if source_table_fqtn -%}
-        {%- set database, schema, table = source_table_fqtn.split('.') -%}
-    {%- endif -%}
-        SELECT COLUMN_NAME FROM {{ database }}.information_schema.columns
-        WHERE TABLE_CATALOG = '{{ database|upper }}'
-        AND   TABLE_SCHEMA = '{{ schema|upper }}'
-        AND   TABLE_NAME = '{{ table|upper }}'
+    select top 0 * from {{ source_table_fqtn }}
 {%- endmacro -%}
 
 {# Jinja Macro to get the table name from source_id #}
@@ -21,11 +14,11 @@ the columns in a table by fqtn
 
 {# Get all Columns in Source Table #}
 {%- set col_names_source_df = run_query(get_source_col_names(source_table_fqtn=source_table)) -%}
-{%- set source_col_names = col_names_source_df['COLUMN_NAME'].to_list() -%}
+{%- set source_col_names = col_names_source_df.columns -%}
 
 {# Get all Columns and Table Name in Join Table #}
 {%- set col_names_join_df = run_query(get_source_col_names(source_table_fqtn=join_table)) -%}
-{%- set join_col_names = col_names_join_df['COLUMN_NAME'].to_list() -%}
+{%- set join_col_names = col_names_join_df.columns -%}
 {%- set join_table_name = get_table_name(join_table) -%}
 
 

--- a/table_transforms/join/join.sql
+++ b/table_transforms/join/join.sql
@@ -8,7 +8,7 @@ the columns in a table by fqtn
 
 {# Jinja Macro to get the table name from source_id #}
 {%- macro get_table_name(join_table) -%}
-    {%- set database, schema, table = join_table.split('.') -%}
+    {%- set table = join_table.split('.')[-1] -%}
     {{ table }}
 {%- endmacro -%}
 

--- a/table_transforms/multi_join/multi_join.sql
+++ b/table_transforms/multi_join/multi_join.sql
@@ -1,10 +1,6 @@
 {# Jinja Macro to get columns for a table #}
 {%- macro get_column_names(fqtn) -%}
-    {%- set database, schema, table = fqtn.split('.') -%}
-    SELECT COLUMN_NAME FROM {{ database }}.information_schema.columns
-    WHERE TABLE_CATALOG = '{{ database|upper }}'
-    AND   TABLE_SCHEMA = '{{ schema|upper }}'
-    AND   TABLE_NAME = '{{ table|upper }}'
+    select top 0 * from {{ source_table_fqtn }}
 {%- endmacro -%}
 
 
@@ -18,7 +14,7 @@ t0.*
 {%- set table_alias = cleanse_name(join_prefixes[loop.index-1]) -%}
 {%- set o_loop = loop -%}
 {%- set col_names_df = run_query(get_column_names(fqtn=fqtn)) -%}
-{%- set col_names = col_names_df['COLUMN_NAME'].to_list() -%}
+{%- set col_names = col_names_df.columns -%}
     {% for column in col_names %}
 , t{{o_loop.index}}.{{column}} as {{ table_alias~'_'~column }}
     {%- endfor %}

--- a/table_transforms/multi_union/multi_union.sql
+++ b/table_transforms/multi_union/multi_union.sql
@@ -1,6 +1,6 @@
 {# Jinja Macro to get the table name from fqtn #}
 {%- macro get_table_name(fqtn) -%}
-    {%- set database, schema, table = fqtn.split('.') -%}
+    {%- set table = fqtn.split('.')[-1] -%}
     {{ table }}
 {%- endmacro -%}
 

--- a/table_transforms/union/union.sql
+++ b/table_transforms/union/union.sql
@@ -3,23 +3,16 @@ Jinja Macro to generate a query that would get all
 the columns in a table by fqtn
 #}
 {%- macro get_source_col_names(source_table_fqtn=None) -%}
-    {%- set database, schema, table = '', '', '' -%}
-    {%- if source_table_fqtn -%}
-        {%- set database, schema, table = source_table_fqtn.split('.') -%}
-    {%- endif -%}
-        SELECT COLUMN_NAME FROM {{ database }}.information_schema.columns
-        WHERE TABLE_CATALOG = '{{ database|upper }}'
-        AND   TABLE_SCHEMA = '{{ schema|upper }}'
-        AND   TABLE_NAME = '{{ table|upper }}'
+    select top 0 * from {{ source_table_fqtn }}
 {%- endmacro -%}
 
 {# Get all Columns in Source Table #}
 {%- set col_names_source_df = run_query(get_source_col_names(source_table_fqtn=source_table)) -%}
-{%- set source_col_names = col_names_source_df['COLUMN_NAME'].to_list() -%}
+{%- set source_col_names = col_names_source_df.columns -%}
 
 {# Get all columns in Inputted Source #}
 {%- set col_names_other_source_df = run_query(get_source_col_names(source_table_fqtn=dataset2)) -%}
-{%- set other_source_col_names = col_names_other_source_df['COLUMN_NAME'].to_list() -%}
+{%- set other_source_col_names = col_names_other_source_df.columns -%}
 
 {# Get Unique Columns Across Both Datasets #}
 {%- set union_cols = source_col_names + other_source_col_names -%}


### PR DESCRIPTION
The Rasgo open source package will support non-Snowflake DataWarehouses much sooner than our API will. Two major changes will be needed to support running these transforms in an open source package:
1. Don't assume source_table arg will conform to Snowflake's fqtn format
2. Don't assume we can hit a view named `information_schema` in the DW

This PR does not address these issues entirely, but chips away at them by:
- removing calls to information_schema when a simple SELECT TOP 0 will suffice
- refactors macros that use .split() with an assumption that the table will be a fqtn

...Needs more testing...