### PR TITLE
Replace CTEs with Subqueries

### DIFF
--- a/rasgotransforms/rasgotransforms/column_transforms/label_encode/label_encode.sql
+++ b/rasgotransforms/rasgotransforms/column_transforms/label_encode/label_encode.sql
@@ -1,6 +1,8 @@
-with distinct_values as (
-    select array_agg(distinct {{ column }}) within group (order by {{ column }} asc) as all_values_array from {{ source_table }}
-)
 select *,
-array_position({{ column }}::variant,all_values_array) as {{ column }}_encoded
-from distinct_values,{{ source_table }}
+  array_position({{ column }}::variant, all_values_array) as {{ column }}_encoded
+from (
+  select 
+    array_agg(distinct {{ column }}) within group (order by {{ column }} asc) as all_values_array 
+    from {{ source_table }}
+) as distinct_values,
+{{ source_table }}

--- a/rasgotransforms/rasgotransforms/column_transforms/target_encode/target_encode.sql
+++ b/rasgotransforms/rasgotransforms/column_transforms/target_encode/target_encode.sql
@@ -1,10 +1,10 @@
-with means as (
-    select distinct {{column}} as value, ROUND(AVG({{target}}), 3) as {{column}}_target_encoded
-    from {{ source_table }}
-    group by value)
-
 select t.*, m.{{column}}_target_encoded
 from {{ source_table }} t
-left join
-means m
+left join (
+  select 
+    distinct {{column}} as value, 
+    ROUND(AVG({{target}}), 3) as {{column}}_target_encoded
+  from {{ source_table }}
+  group by value
+) m
 on t.{{column}} = m.value

--- a/rasgotransforms/rasgotransforms/table_transforms/datespine/datespine.sql
+++ b/rasgotransforms/rasgotransforms/table_transforms/datespine/datespine.sql
@@ -4,24 +4,21 @@ select datediff({{ interval_type }}, '{{ start_timestamp }}'::timestamp_ntz, '{{
 {% set row_count_query_results = run_query(row_count_query) %}
 {% set row_count = row_count_query_results[row_count_query_results.columns[0]][0] %}
 
-with date_spine as (
-    select
-           row_number() over (order by null) as interval_id,
-           dateadd(
-               '{{ interval_type }}',
-               interval_id - 1,
-               '{{ start_timestamp }}'::timestamp_ntz) as ts_ntz_interval_start,
-            dateadd(
-               '{{ interval_type }}',
-               interval_id,
-               '{{ start_timestamp }}'::timestamp_ntz) as ts_ntz_interval_end
-from table (generator(rowcount => {{ row_count }}))
-    )
 select  {{ source_table }}.*,
   date_spine.ts_ntz_interval_start as {{ date_col }}_spine_start,
   date_spine.ts_ntz_interval_end as {{ date_col }}_spine_end
-from date_spine
+from (
+  select
+    row_number() over (order by null) as interval_id,
+    dateadd('{{ interval_type }}', 
+            interval_id - 1,
+            '{{ start_timestamp }}'::timestamp_ntz) as ts_ntz_interval_start,
+    dateadd('{{ interval_type }}',
+            interval_id,
+            '{{ start_timestamp }}'::timestamp_ntz) as ts_ntz_interval_end
+  from table (generator(rowcount => {{ row_count }})) 
+) date_spine
 left join {{ source_table }} on
-    {{ source_table }}.{{ date_col }} >= date_spine.ts_ntz_interval_start
-    and
-    {{ source_table }}.{{ date_col }} < date_spine.ts_ntz_interval_end
+  {{ source_table }}.{{ date_col }} >= date_spine.ts_ntz_interval_start
+  and
+  {{ source_table }}.{{ date_col }} < date_spine.ts_ntz_interval_end

--- a/rasgotransforms/rasgotransforms/table_transforms/market_basket/market_basket.sql
+++ b/rasgotransforms/rasgotransforms/table_transforms/market_basket/market_basket.sql
@@ -1,13 +1,12 @@
-WITH order_detail as
-(SELECT {{transaction_id}},
-listagg({{agg_column}}, '{{sep}}')
-WITHIN group (order by {{agg_column}}) as {{agg_column}}_listagg,
-COUNT({{agg_column}}) as num_products
-FROM {{ source_table }}
-GROUP BY {{transaction_id}} )
-
 SELECT {{agg_column}}_listagg, count({{transaction_id}}) as NumTransactions
-FROM order_detail
+FROM (
+  SELECT {{transaction_id}},
+    listagg({{agg_column}}, '{{sep}}')
+    WITHIN group (order by {{agg_column}}) as {{agg_column}}_listagg,
+    COUNT({{agg_column}}) as num_products
+  FROM {{ source_table }}
+  GROUP BY {{transaction_id}} 
+) order_detail
 where num_products > 1
 GROUP BY {{agg_column}}_listagg
 order by count({{transaction_id}}) desc


### PR DESCRIPTION
Currently rasgoql's CTE chain logic doesn't play nice with CTEs in transforms. That will need to be fixed eventually. 
The few transforms that use CTEs currently can all be switched to subqueries without performance impact. This can buy us some time.