### PR TITLE
dependencies across packages

### DIFF
--- a/rasgotransforms/rasgotransforms/main.py
+++ b/rasgotransforms/rasgotransforms/main.py
@@ -25,6 +25,7 @@ class Datawarehouse(Enum):
     """
     BIGQUERY = 'bigquery'
     SNOWFLAKE = 'snowflake'
+    POSTGRESQL = 'postgresql'
 
 class TransformTemplate:
     """

--- a/rasgotransforms/rasgotransforms/version.py
+++ b/rasgotransforms/rasgotransforms/version.py
@@ -1,4 +1,4 @@
 """
 Package version for pypi
 """
-__version__ = '1.0.0'
+__version__ = '1.0.1'


### PR DESCRIPTION
So RasgoQL uses this method from RasgoTransforms  when determining if we have a valid DW type or not. I need to make this change to continue to test my postgresql changes for RasgoQL