### PR TITLE
rename name param to new_col_name for concat transform

### DIFF
--- a/docs/concat.md
+++ b/docs/concat.md
@@ -9,10 +9,10 @@ Pass in a list named "concat_list", containing the names of the columns and the 
 
 ## Parameters
 
-|  Argument   |    Type    |                       Description                       | Is Optional |
-| ----------- | ---------- | ------------------------------------------------------- | ----------- |
-| concat_list | mixed_list | A list representing each new column to be created.      |             |
-| name        | value      | A name for the new column created by the concatenation. | True        |
+|   Argument   |    Type    |                       Description                       | Is Optional |
+| ------------ | ---------- | ------------------------------------------------------- | ----------- |
+| concat_list  | mixed_list | A list representing each new column to be created.      |             |
+| new_col_name | value      | A name for the new column created by the concatenation. | True        |
 
 
 ## Example
@@ -21,7 +21,8 @@ Pass in a list named "concat_list", containing the names of the columns and the 
 product = rasgo.get.dataset(75)
 ds2 = product.concat(
   concat_list=['PRODUCTKEY', 'PRODUCTALTERNATEKEY', "' hybridkey'"],
-  name='Hybrid Key')
+  new_col_name='Hybrid Key'
+)
 
 ds2.preview()
 ```

--- a/rasgotransforms/rasgotransforms/column_transforms/concat/concat.sql
+++ b/rasgotransforms/rasgotransforms/column_transforms/concat/concat.sql
@@ -1,5 +1,5 @@
-{%- if name is defined -%}
-    {%- set alias = cleanse_name(name) -%}
+{%- if new_col_name is defined -%}
+    {%- set alias = cleanse_name(new_col_name) -%}
 {%- else -%}
     {%- set alias = 'CONCAT_'~ cleanse_name(concat_list | join('_')) -%}
 {%- endif -%}

--- a/rasgotransforms/rasgotransforms/column_transforms/concat/concat.yaml
+++ b/rasgotransforms/rasgotransforms/column_transforms/concat/concat.yaml
@@ -12,7 +12,7 @@ arguments:
   concat_list:
     type: mixed_list
     description: A list representing each new column to be created.
-  name:
+  new_col_name:
     type: value
     is_optional: true
     description: A name for the new column created by the concatenation.
@@ -20,6 +20,7 @@ example_code: |
   product = rasgo.get.dataset(75)
   ds2 = product.concat(
     concat_list=['PRODUCTKEY', 'PRODUCTALTERNATEKEY', "' hybridkey'"],
-    name='Hybrid Key')
+    new_col_name='Hybrid Key'
+  )
 
   ds2.preview()

--- a/rasgotransforms/rasgotransforms/version.py
+++ b/rasgotransforms/rasgotransforms/version.py
@@ -1,4 +1,4 @@
 """
 Package version for pypi
 """
-__version__ = '1.1.0'
+__version__ = '1.1.1'


### PR DESCRIPTION
Renamed concat apram `name` to `new_col_name`.

Need to add since we call `self. transform(name=transform.name, *arg, **kwargs)` and kwargs would contain a param called `name` forcing two kwargs called `name` supplied to the function which a rises an exception.