### PR TITLE
allow no group by and add entropy calculations

### DIFF
--- a/docs/aggregate.md
+++ b/docs/aggregate.md
@@ -8,7 +8,7 @@ Groups rows by the group_by items applying aggregations functions for the result
 
 |   Argument   |    Type     |                                                             Description                                                             | Is Optional |
 | ------------ | ----------- | ----------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| group_by     | column_list | Columns to group by                                                                                                                 |             |
+| group_by     | column_list | Columns to group by                                                                                                                 | True        |
 | aggregations | agg_dict    | Aggregations to apply for other columns. Dict keys are column names, and values are a list of aggegations to apply for that column. |             |
 
 
@@ -22,6 +22,10 @@ ds2 = ds.aggregate(group_by=['FIPS'], aggregations={
           'COL_2': ['SUM', 'AVG']
       })
 ds2.preview()
+
+ds3 = ds.aggregate(aggregations={'COL_1': ['SUM']})
+
+ds4 = ds.aggregate(aggregations={'DISTINCT COL_1': ['SUM']})
 ```
 
 ## Source Code

--- a/docs/apply.md
+++ b/docs/apply.md
@@ -2,7 +2,7 @@
 
 # apply
 
-A transform that accepts a custom template to execute. Must use the sql template argument `source_table` to reference the Rasgo dataset which will serve as the base of any SELECT
+A transform that accepts a custom template to execute. Must use the sql template argument `source_table` to reference the Rasgo dataset which will serve as the base of any SELECT. Other templatized parameters must also be passed in as kwargs.
 
 ## Parameters
 
@@ -17,9 +17,11 @@ A transform that accepts a custom template to execute. Must use the sql template
 ds = rasgo.get.dataset(id)
 
 ds2 = ds.apply(
-  sql='SELECT * FROM {{ source_table }} WHERE COLUMNVALUE = I17'
+  sql='SELECT * FROM {{ source_table }} WHERE COLUMNVALUE = I17',
+  source_table='db.schema.table'
 )
 ds2.preview()
+#TODO Add args 
 ```
 
 ## Source Code

--- a/docs/apply.md
+++ b/docs/apply.md
@@ -17,11 +17,16 @@ A transform that accepts a custom template to execute. Must use the sql template
 ds = rasgo.get.dataset(id)
 
 ds2 = ds.apply(
-  sql='SELECT * FROM {{ source_table }} WHERE COLUMNVALUE = I17',
-  source_table='db.schema.table'
+  sql='SELECT * FROM {{ source_table }} WHERE {{ where_column }} = {{ where_value }}',
+  where_column='NEW_LEADS_COL',
+  where_value=100
+)
+
+ds2 = ds.apply(
+  sql='SELECT * FROM {{ source_table }} WHERE COLUMNVALUE = I17'
 )
 ds2.preview()
-#TODO Add args 
+
 ```
 
 ## Source Code

--- a/rasgotransforms/rasgotransforms/table_transforms/aggregate/aggregate.sql
+++ b/rasgotransforms/rasgotransforms/table_transforms/aggregate/aggregate.sql
@@ -1,13 +1,40 @@
+{%- set entropy_aggs = {} -%}
+{%- set from_tables = [source_table] -%}
+{%- for col, aggs in aggregations.items() -%}
+    {%- if 'ENTROPY' in aggs -%}
+        {%- set _ = entropy_aggs.update({col: aggs}) -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{%- for col, aggs in entropy_aggs.items() -%}
+    {%- if loop.first %}
+        with
+    {%- endif %}
+    {{ col }}_COUNTS as (
+        select {{col}}, count(*) as c from {{ source_table }} group by 1
+    ),
+    {{ col }}_RATIOS as (
+        select ratio_to_report(c) over() p_{{col}} from {{ col }}_COUNTS
+    ) {{ ',' if not loop.last }}
+    {%- set _ = from_tables.append(col+'_RATIOS')  -%}
+{%- endfor -%}
 SELECT
-{%- for group_item in group_by %}
+{% for group_item in group_by -%}
     {{ group_item }},
 {%- endfor -%}
 
-{%- for col, aggs in aggregations.items() %}
+{%- for col, aggs in aggregations.items() -%}
         {%- set outer_loop = loop -%}
-    {%- for agg in aggs %}
-    {{ agg }}({{ col }}) as {{ col + '_' + agg }}{{ '' if loop.last and outer_loop.last else ',' }}
+    {%- for agg in aggs -%}
+        {%- if agg == 'ENTROPY' -%}
+            -sum(p_{{ col }}*log(2,p_{{ col }})) as {{ col }}_entropy
+        {%- else -%}
+            {{ agg }}({{ col }}) as {{ col + '_' + agg }}
+        {%- endif -%}
+        {{ '' if loop.last and outer_loop.last else ',' }}
     {%- endfor -%}
 {%- endfor %}
-FROM {{ source_table }}
-GROUP BY {{ group_by | join(', ') }}
+FROM {{ from_tables | join(', ') }}
+{%- if group_by -%}
+    GROUP BY {{ group_by | join(', ') }}
+{%- endif -%}

--- a/rasgotransforms/rasgotransforms/table_transforms/aggregate/aggregate.sql
+++ b/rasgotransforms/rasgotransforms/table_transforms/aggregate/aggregate.sql
@@ -35,6 +35,6 @@ SELECT
     {%- endfor -%}
 {%- endfor %}
 FROM {{ from_tables | join(', ') }}
-{%- if group_by -%}
+{% if group_by -%}
     GROUP BY {{ group_by | join(', ') }}
 {%- endif -%}

--- a/rasgotransforms/rasgotransforms/table_transforms/aggregate/aggregate.yaml
+++ b/rasgotransforms/rasgotransforms/table_transforms/aggregate/aggregate.yaml
@@ -8,6 +8,7 @@ arguments:
   group_by:
     type: column_list
     description: Columns to group by
+    is_optional: true
   aggregations:
     type: agg_dict
     description: Aggregations to apply for other columns. Dict keys are column names, and values are a list of aggegations to apply for that column.
@@ -19,3 +20,7 @@ example_code: |
             'COL_2': ['SUM', 'AVG']
         })
   ds2.preview()
+
+  ds3 = ds.aggregate(aggregations={'COL_1': ['SUM']})
+
+  ds4 = ds.aggregate(aggregations={'DISTINCT COL_1': ['SUM']})

--- a/rasgotransforms/rasgotransforms/table_transforms/apply/apply.yaml
+++ b/rasgotransforms/rasgotransforms/table_transforms/apply/apply.yaml
@@ -4,7 +4,7 @@ tags:
   - custom
   - reshape
   - aggregate
-description: A transform that accepts a custom template to execute. Must use the sql template argument `source_table` to reference the Rasgo dataset which will serve as the base of any SELECT
+description: A transform that accepts a custom template to execute. Must use the sql template argument `source_table` to reference the Rasgo dataset which will serve as the base of any SELECT. Other templatized parameters must also be passed in as kwargs.
 arguments:
   sql:
     type: custom
@@ -13,6 +13,8 @@ example_code: |
   ds = rasgo.get.dataset(id)
 
   ds2 = ds.apply(
-    sql='SELECT * FROM {{ source_table }} WHERE COLUMNVALUE = I17'
+    sql='SELECT * FROM {{ source_table }} WHERE COLUMNVALUE = I17',
+    source_table='db.schema.table'
   )
   ds2.preview()
+  #TODO Add args 

--- a/rasgotransforms/rasgotransforms/table_transforms/apply/apply.yaml
+++ b/rasgotransforms/rasgotransforms/table_transforms/apply/apply.yaml
@@ -13,8 +13,12 @@ example_code: |
   ds = rasgo.get.dataset(id)
 
   ds2 = ds.apply(
-    sql='SELECT * FROM {{ source_table }} WHERE COLUMNVALUE = I17',
-    source_table='db.schema.table'
+    sql='SELECT * FROM {{ source_table }} WHERE {{ where_column }} = {{ where_value }}',
+    where_column='NEW_LEADS_COL',
+    where_value=100
+  )
+
+  ds2 = ds.apply(
+    sql='SELECT * FROM {{ source_table }} WHERE COLUMNVALUE = I17'
   )
   ds2.preview()
-  #TODO Add args 


### PR DESCRIPTION
allows you to leave off group_by argument and allows you to get an ENTROPY calc for a column.  This change has two caveats:
1. The system can't stop you from being dumb and trying to get single column agg values and add a group by. If you do that you get invalid sql and it will fail on application to a dataset.
2. The template will break if a user tries to use ENTROPY in a DB environment that does not have `ratio_to_report` function


Test1 (works):

input:
```
---
aggregations:
  PRODUCTCATEGORYALTERNATEKEY:
  - SUM
  - ENTROPY
  PRODUCTCATEGORYKEY:
  - SUM
  - ENTROPY
source_table: ADVENTUREWORKS.PUBLIC.DIMPRODUCTCATEGORY`

```

sql:
```
        with
    PRODUCTCATEGORYALTERNATEKEY_COUNTS as (
        select PRODUCTCATEGORYALTERNATEKEY, count(*) as c from ADVENTUREWORKS.PUBLIC.DIMPRODUCTCATEGORY group by 1
    ),
    PRODUCTCATEGORYALTERNATEKEY_RATIOS as (
        select ratio_to_report(c) over() p_PRODUCTCATEGORYALTERNATEKEY from PRODUCTCATEGORYALTERNATEKEY_COUNTS
    ) ,
    PRODUCTCATEGORYKEY_COUNTS as (
        select PRODUCTCATEGORYKEY, count(*) as c from ADVENTUREWORKS.PUBLIC.DIMPRODUCTCATEGORY group by 1
    ),
    PRODUCTCATEGORYKEY_RATIOS as (
        select ratio_to_report(c) over() p_PRODUCTCATEGORYKEY from PRODUCTCATEGORYKEY_COUNTS
    ) SELECT
SUM(PRODUCTCATEGORYALTERNATEKEY) as PRODUCTCATEGORYALTERNATEKEY_SUM,-sum(p_PRODUCTCATEGORYALTERNATEKEY*log(2,p_PRODUCTCATEGORYALTERNATEKEY)) as PRODUCTCATEGORYALTERNATEKEY_entropy,SUM(PRODUCTCATEGORYKEY) as PRODUCTCATEGORYKEY_SUM,-sum(p_PRODUCTCATEGORYKEY*log(2,p_PRODUCTCATEGORYKEY)) as PRODUCTCATEGORYKEY_entropy
FROM ADVENTUREWORKS.PUBLIC.DIMPRODUCTCATEGORY, PRODUCTCATEGORYALTERNATEKEY_RATIOS, PRODUCTCATEGORYKEY_RATIOS
```

Output:
```
PRODUCTCATEGORYALTERNATEKEY_SUM	PRODUCTCATEGORYALTERNATEKEY_ENTROPY	PRODUCTCATEGORYKEY_SUM	PRODUCTCATEGORYKEY_ENTROPY
160	32	160	32
```

Test 2:
input:
```
---
group_by:
- ENGLISHPRODUCTCATEGORYNAME
aggregations:
  PRODUCTCATEGORYKEY:
  - SUM
  - AVG
  PRODUCTCATEGORYALTERNATEKEY:
  - SUM
  - AVG
source_table: ADVENTUREWORKS.PUBLIC.DIMPRODUCTCATEGORY

```

sql:
```
SELECT
ENGLISHPRODUCTCATEGORYNAME,SUM(PRODUCTCATEGORYALTERNATEKEY) as PRODUCTCATEGORYALTERNATEKEY_SUM,AVG(PRODUCTCATEGORYALTERNATEKEY) as PRODUCTCATEGORYALTERNATEKEY_AVG,SUM(PRODUCTCATEGORYKEY) as PRODUCTCATEGORYKEY_SUM,AVG(PRODUCTCATEGORYKEY) as PRODUCTCATEGORYKEY_AVG
FROM ADVENTUREWORKS.PUBLIC.DIMPRODUCTCATEGORY
GROUP BY ENGLISHPRODUCTCATEGORYNAME
```

output:
```
ENGLISHPRODUCTCATEGORYNAME	PRODUCTCATEGORYALTERNATEKEY_SUM	PRODUCTCATEGORYALTERNATEKEY_AVG	PRODUCTCATEGORYKEY_SUM	PRODUCTCATEGORYKEY_AVG
Bikes	1	1.000000	1	1.000000
Components	2	2.000000	2	2.000000
Clothing	3	3.000000	3	3.000000
Accessories	4	4.000000	4	4.000000
```