### PR TITLE
Add support for Redshift

### DIFF
--- a/rasgotransforms/rasgotransforms/main.py
+++ b/rasgotransforms/rasgotransforms/main.py
@@ -23,7 +23,7 @@ class Datawarehouse(Enum):
     SNOWFLAKE = "snowflake"
     POSTGRESQL = "postgresql"
     MYSQL = "mysql"
-
+    REDSHIFT = "redshift"
 
 class TransformTemplate:
     """
@@ -148,7 +148,7 @@ def _load_all_yaml_files(datawarehouse: str) -> Dict[str, Dict]:
         try:
             transform_data = _read_yaml(transform_yaml_path)
             transform_yamls[transform_name] = transform_data
-        except Exception:
+        except FileNotFoundError:
             continue
 
     return transform_yamls

--- a/rasgotransforms/rasgotransforms/transforms/dateadd/redshift/dateadd.sql
+++ b/rasgotransforms/rasgotransforms/transforms/dateadd/redshift/dateadd.sql
@@ -1,0 +1,3 @@
+SELECT *,
+  {{ date }} + INTERVAL '{{ offset }} {{ date_part }}' AS {{ cleanse_name(date + 'add' + offset|string + date_part) }}
+FROM {{ source_table }}

--- a/rasgotransforms/rasgotransforms/transforms/datepart/redshift/datepart.sql
+++ b/rasgotransforms/rasgotransforms/transforms/datepart/redshift/datepart.sql
@@ -1,0 +1,5 @@
+SELECT *,
+{%- for target_col, date_part in dates.items() %}
+  DATE_PART('{{date_part}}', {{target_col}}) AS {{target_col}}_{{date_part}} {{ ", " if not loop.last else "" }}
+{%- endfor %}
+FROM {{ source_table }}

--- a/rasgotransforms/rasgotransforms/transforms/datetrunc/redshift/datetrunc.sql
+++ b/rasgotransforms/rasgotransforms/transforms/datetrunc/redshift/datetrunc.sql
@@ -1,0 +1,5 @@
+SELECT *,
+{%- for target_col, date_part in dates.items() %}
+  DATE_TRUNC({{date_part}}, {{target_col}}) as {{target_col}}_{{date_part}} {{ ", " if not loop.last else "" }}
+{%- endfor %}
+FROM {{ source_table }}

--- a/rasgotransforms/rasgotransforms/version.py
+++ b/rasgotransforms/rasgotransforms/version.py
@@ -1,4 +1,4 @@
 """
 Package version for pypi
 """
-__version__ = "1.3.0"
+__version__ = "1.3.1"

--- a/rasgotransforms/rasgotransforms/version.py
+++ b/rasgotransforms/rasgotransforms/version.py
@@ -1,4 +1,4 @@
 """
 Package version for pypi
 """
-__version__ = "1.4.0"
+__version__ = "1.5.0"

--- a/rasgotransforms/rasgotransforms/version.py
+++ b/rasgotransforms/rasgotransforms/version.py
@@ -1,4 +1,4 @@
 """
 Package version for pypi
 """
-__version__ = "1.3.1"
+__version__ = "1.4.0"


### PR DESCRIPTION
These are a copy of the files from postgresql, as redshift has the same syntax. Confirmed `dateadd` working directly, and that the docs are the same for [`date_part` ](https://docs.aws.amazon.com/redshift/latest/dg/r_DATE_PART_function.html) and [`date_trunc`](https://docs.aws.amazon.com/redshift/latest/dg/r_DATE_TRUNC.html)