### PR TITLE
what if the distinct values in a column are numeric?

### DIFF
--- a/docs/funnel.md
+++ b/docs/funnel.md
@@ -1,14 +1,14 @@
 
 
-# funnel
+# sankey
 
 Analyze the hierarchical record count of a series of columns by counting the number of records in each pair of values in hierarchically adjacent columns.
 
 ## Parameters
 
-| Argument  |    Type     |                         Description                          | Is Optional |
-| --------- | ----------- | ------------------------------------------------------------ | ----------- |
-| hierarchy | column_list | Ordered list of columns, from highest in hierarchy to lowest |             |
+| Argument |    Type     |                         Description                          | Is Optional |
+| -------- | ----------- | ------------------------------------------------------------ | ----------- |
+| stage    | column_list | Ordered list of columns, from highest in hierarchy to lowest |             |
 
 
 ## Example
@@ -16,7 +16,7 @@ Analyze the hierarchical record count of a series of columns by counting the num
 ```python
 ds = rasgo.get.dataset(id)
 
-ds2 = ds.funnel(hierarchy=["ENGLISHCOUNTRYREGIONNAME", "STATEPROVINCENAME", "CITY"])
+ds2 = ds.funnel(stage=["ENGLISHCOUNTRYREGIONNAME", "STATEPROVINCENAME", "CITY"])
 ds2.preview()
 
 ```

--- a/rasgotransforms/rasgotransforms/transforms/funnel/funnel.sql
+++ b/rasgotransforms/rasgotransforms/transforms/funnel/funnel.sql
@@ -1,7 +1,7 @@
-{%- for i in range((hierarchy|length) - 1) -%}
+{%- for i in range((stage|length) - 1) -%}
     SELECT
-    CAST({{ hierarchy[i] }} AS STRING) AS SOURCE_NODE,
-    CAST({{ hierarchy[i+1] }} AS STRING) AS DEST_NODE,
+    CAST({{ stage[i] }} AS STRING) AS SOURCE_NODE,
+    CAST({{ stage[i+1] }} AS STRING) AS DEST_NODE,
     COUNT(*) AS WIDTH
 FROM {{ source_table }}
 GROUP BY

--- a/rasgotransforms/rasgotransforms/transforms/funnel/funnel.sql
+++ b/rasgotransforms/rasgotransforms/transforms/funnel/funnel.sql
@@ -1,7 +1,7 @@
 {%- for i in range((hierarchy|length) - 1) -%}
     SELECT
-    {{ hierarchy[i] }} AS SOURCE_NODE,
-    {{ hierarchy[i+1] }} AS DEST_NODE,
+    CAST({{ hierarchy[i] }} AS STRING) AS SOURCE_NODE,
+    CAST({{ hierarchy[i+1] }} AS STRING) AS DEST_NODE,
     COUNT(*) AS WIDTH
 FROM {{ source_table }}
 GROUP BY

--- a/rasgotransforms/rasgotransforms/transforms/funnel/funnel.yaml
+++ b/rasgotransforms/rasgotransforms/transforms/funnel/funnel.yaml
@@ -1,15 +1,15 @@
-name: funnel
+name: sankey
 type: insight
 context:
   chart_type: sankey
 tags:
 description: Analyze the hierarchical record count of a series of columns by counting the number of records in each pair of values in hierarchically adjacent columns.
 arguments:
-  hierarchy:
+  stage:
     type: column_list
     description: Ordered list of columns, from highest in hierarchy to lowest
 example_code: |
   ds = rasgo.get.dataset(id)
 
-  ds2 = ds.funnel(hierarchy=["ENGLISHCOUNTRYREGIONNAME", "STATEPROVINCENAME", "CITY"])
+  ds2 = ds.funnel(stage=["ENGLISHCOUNTRYREGIONNAME", "STATEPROVINCENAME", "CITY"])
   ds2.preview()


### PR DESCRIPTION
Creating this graph's data entails unioning distinct values from multiple columns into either a `sourced_node` or a `dest_node`. Obviously, if those distinct values are both numeric and varchar types and we don't cast them, we'll get a failure in the template. This PR resolves that issue.