### PR TITLE
publish transforms on staging when merged to main

### DIFF
--- a/.github/workflows/publish_transforms.yaml
+++ b/.github/workflows/publish_transforms.yaml
@@ -31,3 +31,6 @@ jobs:
 
       - name: Publish Transforms on Prod
         run: python python/publish_transforms.py "$RASGO_COMMUNITY_API_KEY" -d production
+
+      - name: Publish Transforms on Staging
+          run: python python/publish_transforms.py "$RASGO_STAGING_COMMUNITY_API_KEY" -d staging


### PR DESCRIPTION
We need to set the GitHub secret `$RASGO_STAGING_COMMUNITY_API_KEY` before this gets deployed for it to work