### PR TITLE
prepend column names to avoid charting issues

### DIFF
--- a/rasgotransforms/rasgotransforms/transforms/sankey/sankey.sql
+++ b/rasgotransforms/rasgotransforms/transforms/sankey/sankey.sql
@@ -1,7 +1,7 @@
 {%- for i in range((stage|length) - 1) -%}
     SELECT
-    CAST({{ stage[i] }} AS STRING) AS SOURCE_NODE,
-    CAST({{ stage[i+1] }} AS STRING) AS DEST_NODE,
+    '{{ stage[i] }}' || CAST({{ stage[i] }} AS STRING) AS SOURCE_NODE,
+    '{{ stage[i+1] }}' || CAST({{ stage[i+1] }} AS STRING) AS DEST_NODE,
     COUNT(*) AS WIDTH
 FROM {{ source_table }}
 GROUP BY
@@ -9,5 +9,5 @@ GROUP BY
     DEST_NODE
 HAVING
     SOURCE_NODE IS NOT NULL AND DEST_NODE IS NOT NULL
-{{ "UNION" if not loop.last else "" }}
+{{ "UNION ALL" if not loop.last else "" }}
 {% endfor %}

--- a/rasgotransforms/rasgotransforms/transforms/sankey/sankey.sql
+++ b/rasgotransforms/rasgotransforms/transforms/sankey/sankey.sql
@@ -1,7 +1,7 @@
 {%- for i in range((stage|length) - 1) -%}
     SELECT
-    '{{ stage[i] }}' || CAST({{ stage[i] }} AS STRING) AS SOURCE_NODE,
-    '{{ stage[i+1] }}' || CAST({{ stage[i+1] }} AS STRING) AS DEST_NODE,
+    '{{ stage[i] }}_' || CAST({{ stage[i] }} AS STRING) AS SOURCE_NODE,
+    '{{ stage[i+1] }}_' || CAST({{ stage[i+1] }} AS STRING) AS DEST_NODE,
     COUNT(*) AS WIDTH
 FROM {{ source_table }}
 GROUP BY


### PR DESCRIPTION
@itsamejoshab This should fix the charting issues you noticed with Sankey graphs.

@phillip-rasgo, Prepending column names to avoid duplicate values and changing `UNION` to `UNION ALL` to preserve order