### PR TITLE
flatten output data pivoted by dimensions

### DIFF
--- a/docs/metric.md
+++ b/docs/metric.md
@@ -17,6 +17,7 @@ Calculate metric values given a metric definition
 | alias             | string      | The name of the output metric value column                                                                                                                                                     | True        |
 | start_date        | timestamp   | The start of the period for which metric values will be calculated (2010-01-01 if unset)                                                                                                       | True        |
 | num_days          | int         | The number of days after the start_date for which metric values will be calculated (7300 if unset)                                                                                             | True        |
+| flatten           | bool        | (Default: true) If true, the resulting data will be pivoted on the distinct dimension columns                                                                                                  | True        |
 
 
 ## Example

--- a/rasgotransforms/rasgotransforms/transforms/metric/metric.sql
+++ b/rasgotransforms/rasgotransforms/transforms/metric/metric.sql
@@ -3,6 +3,28 @@
 {%- set alias = 'metric_value' if not alias else alias -%}
 {%- set distinct = true if 'distinct' in aggregation_type|lower else false -%}
 {%- set aggregation_type = aggregation_type|upper|replace('_', '')|replace('DISTINCT', '')|replace('MEAN', 'AVG') -%}
+{%- set flatten = flatten if flatten is defined else true -%}
+
+{%- macro get_distinct_values(columns) -%}
+    {%- set distinct_val_query -%}
+        select distinct
+            {%- for column in columns %}
+            {{ column }}{{', ' if not loop.last else ''}}
+            {%- endfor %}
+        from {{ source_table }} limit 101
+    {%- endset -%}
+    {%- set distinct_vals = run_query(distinct_val_query) -%}
+    {%- if distinct_vals.shape[0] > 100 %}
+        {{ raise_exception('There are more than 100 distinct groups given the current dimensions. Please select dimensions with fewer distinct groups to aggregate by.') }}
+    {%- endif -%}
+    {%- for val in distinct_vals.itertuples() -%}
+        _
+        {%- for column in distinct_vals.columns -%}
+            {{ val[column] }}{{'_' if not loop.last else ''}}
+        {%- endfor -%}
+        {{ ',' if not loop.last else ''}}
+    {%- endfor %}
+{%- endmacro -%}
 
 with source_query as (
     select
@@ -78,7 +100,7 @@ bounded as (
             max(case when has_data then period end) over ()  as upper_bound
     from joined
 ),
-final as (
+tidy_data as (
     select
         cast(period as timestamp) as period_min,
         {%- if time_grain|lower == 'quarter' %}
@@ -95,4 +117,50 @@ final as (
     and period <= upper_bound
     order by {{ range(1, dimensions|length + 2)|join(', ') }}
 )
-select * from final
+{%- if not dimensions or not flatten %}
+select * from tidy_data
+{%- else -%}
+{%- set distinct_values = get_distinct_values(dimensions).split(',') -%}
+, 
+combined_dimensions as (
+    select
+        concat('_', 
+        {%- for dimension in dimensions -%} 
+            {{ dimension}}{{ ",'_'," if not loop.last else ''}}
+        {%- endfor -%}) as dimensions,
+        period_min,
+        period_max,
+        {{ alias }}
+    from tidy_data
+),
+pivoted as (
+    select
+        period_min,
+        period_max,
+        {% for val in distinct_values -%}
+        {{ val }}{{',' if not loop.last else ''}}
+        {%- endfor %}
+    from (
+        select 
+            period_min,
+            period_max,
+            {{ alias }},
+            dimensions
+        from combined_dimensions
+    )
+    pivot (
+        sum({{ alias }}) for dimensions in (
+            {% for val in distinct_values -%}
+            '{{ val }}'{{',' if not loop.last else ''}}
+            {%- endfor %}
+        )
+    ) as p (
+        period_min,
+        period_max,
+        {% for val in distinct_values -%}
+        {{ val }}{{',' if not loop.last else ''}}
+        {%- endfor %}
+    )
+)
+select * from pivoted
+{%- endif -%}

--- a/rasgotransforms/rasgotransforms/transforms/metric/metric.yaml
+++ b/rasgotransforms/rasgotransforms/transforms/metric/metric.yaml
@@ -36,6 +36,10 @@ arguments:
     type: int
     description: The number of days after the start_date for which metric values will be calculated (7300 if unset)
     is_optional: true
+  flatten:
+    type: bool
+    description: "(Default: true) If true, the resulting data will be pivoted on the distinct dimension columns"
+    is_optional: true
 
 example_code: |
   ds = rasgo.get.dataset(id)


### PR DESCRIPTION
This adds the `flatten` parameter to the metric (true by default) which changes the output format to be pivoted on the unique dimension values.

Current output:
PERIOD_MIN|PERIOD_MAX|DIMENSION_1|DIMENSION_2|METRIC_VALUE
---|---|---|---|---
2012-08-05 00:00:00.000|2012-08-11 23:59:59.000|A|1|12.34
2012-08-05 00:00:00.000|2012-08-11 23:59:59.000|B|1|12.34
2012-08-05 00:00:00.000|2012-08-11 23:59:59.000|B|1|12.34


Flattened output:
PERIOD_MIN|PERIOD_MAX|_A_1|_B_1|_B_2
---|---|---|---|---
2012-08-05 00:00:00.000|2012-08-11 23:59:59.000|12.34|12.34|12.34

*Column names are always lead by an underscore and are delimited with an underscore and in the order that the dimensions are passed in

**If no dimensions are passed, the output remains the same as it was before