### PR TITLE
Add error messaging if we can't run_query

### DIFF
--- a/docs/one_hot_encode.md
+++ b/docs/one_hot_encode.md
@@ -6,9 +6,10 @@ One hot encode a column. Create a null value flag for the column if any of the v
 
 ## Parameters
 
-|  Name  |  Type  |          Description          | Is Optional |
-| ------ | ------ | ----------------------------- | ----------- |
-| column | column | Column name to one-hot encode |             |
+|     Name     |    Type     |                                         Description                                         | Is Optional |
+| ------------ | ----------- | ------------------------------------------------------------------------------------------- | ----------- |
+| column       | column      | Column name to one-hot encode                                                               |             |
+| list_of_vals | string_list | optional argument to override the dynamic lookup of all values in the target one-hot column | True        |
 
 
 ## Example

--- a/rasgotransforms/rasgotransforms/transforms/apply/apply.sql
+++ b/rasgotransforms/rasgotransforms/transforms/apply/apply.sql
@@ -1,3 +1,3 @@
 {# Placeholder code. Will be replaced by user supplied template #} 
 SELECT * FROM {{ source_table }}
-{{ raise_exception('Placeholder code must me replaced by user supplied template') }}
+{{ raise_exception('Placeholder code must be replaced by user supplied template') }}

--- a/rasgotransforms/rasgotransforms/transforms/one_hot_encode/one_hot_encode.sql
+++ b/rasgotransforms/rasgotransforms/transforms/one_hot_encode/one_hot_encode.sql
@@ -1,13 +1,14 @@
 {%- set run_query_error_message -%}
-This transform depends on dynamic values to work, but no Datawarehouse connection is available. 
+This transform depends on dynamic values to work, but no Data Warehouse connection is available. 
 Instead, please use the `list_of_vals` argument to provide these values explicitly
 {%- endset -%}
 
 {%- if list_of_vals is not defined -%}
-    {%- set distinct_col_vals =  run_query("SELECT DISTINCT " +  column + " FROM " + source_table)[column].to_list() -%}
-    {%- if distinct_col_vals is none -%}
+    {%- set results = run_query("SELECT DISTINCT " +  column + " FROM " + source_table) -%}
+    {%- if results is none -%}
         {{ raise_exception(run_query_error_message) }}
     {%- endif -%}
+    {%- set distinct_col_vals = results[column].to_list() -%}
 {%- else -%}
     {%- set distinct_col_vals = list_of_vals -%}
 {%- endif -%}

--- a/rasgotransforms/rasgotransforms/transforms/one_hot_encode/one_hot_encode.sql
+++ b/rasgotransforms/rasgotransforms/transforms/one_hot_encode/one_hot_encode.sql
@@ -1,4 +1,16 @@
-{%- set distinct_col_vals =  run_query("SELECT DISTINCT " +  column + " FROM " + source_table)[column].to_list() -%}
+{%- set run_query_error_message -%}
+This transform depends on dynamic values to work, but no Datawarehouse connection is available. 
+Instead, please use the `list_of_vals` argument to provide these values explicitly
+{%- endset -%}
+
+{%- if list_of_vals is not defined -%}
+    {%- set distinct_col_vals =  run_query("SELECT DISTINCT " +  column + " FROM " + source_table)[column].to_list() -%}
+    {%- if results is none -%}
+        {{ raise_exception(run_query_error_message) }}
+    {%- endif -%}
+{%- else -%}
+    {%- set distinct_col_vals = list_of_vals -%}
+{%- endif -%}
 
 SELECT *,
 {% for val in distinct_col_vals %}

--- a/rasgotransforms/rasgotransforms/transforms/one_hot_encode/one_hot_encode.sql
+++ b/rasgotransforms/rasgotransforms/transforms/one_hot_encode/one_hot_encode.sql
@@ -5,7 +5,7 @@ Instead, please use the `list_of_vals` argument to provide these values explicit
 
 {%- if list_of_vals is not defined -%}
     {%- set distinct_col_vals =  run_query("SELECT DISTINCT " +  column + " FROM " + source_table)[column].to_list() -%}
-    {%- if results is none -%}
+    {%- if distinct_col_vals is none -%}
         {{ raise_exception(run_query_error_message) }}
     {%- endif -%}
 {%- else -%}

--- a/rasgotransforms/rasgotransforms/transforms/one_hot_encode/one_hot_encode.yaml
+++ b/rasgotransforms/rasgotransforms/transforms/one_hot_encode/one_hot_encode.yaml
@@ -7,6 +7,10 @@ arguments:
   column:
     type: column
     description: Column name to one-hot encode
+  list_of_vals:
+    type: string_list
+    description: optional argument to override the dynamic lookup of all values in the target one-hot column
+    is_optional: true
 example_code: |
   ds = rasgo.get.dataset(id)
 

--- a/rasgotransforms/rasgotransforms/transforms/pivot/pivot.sql
+++ b/rasgotransforms/rasgotransforms/transforms/pivot/pivot.sql
@@ -5,7 +5,7 @@ limit 1000
 {%- endset -%}
 
 {%- set run_query_error_message -%}
-This transform depends on dynamic values to work, but no Datawarehouse connection is available. 
+This transform depends on dynamic values to work, but no Data Warehouse connection is available. 
 Instead, please use the `list_of_vals` argument to provide these values explicitly
 {%- endset -%}
 


### PR DESCRIPTION
Transforms to fix: 
* pivot
* one_hot_encode
* datespine
* datespine_groups
* 
We can either:
1. Tell users that SG5K does not have a DW connection and they have to use optional args to make up for that
2. Tell users that something went wrong with this transform, and they can use args X, Y, or Z to fix that. (but not say anything about the DW connection)
  a. If we use option # 2, we need to update the transform templates that we use everywhere, so putting an SG5K-specific error message in there won't apply to other places. If something went wrong in RQL, we can't have an error message about SG5K...
  b. example:
```
{%- set run_query_error_message -%}
This transform depends on dynamic values to work, but no Datawarehouse connection is available. 
Instead, please use the `list_of_vals` argument to provide these values explicitly
{%- endset -%}

{%- set results = run_query(distinct_val_query) -%}
{%- if results is none -%}
    {{ raise_exception(run_query_error_message) }}
{%- endif -%}
```