### PR TITLE
improved datespine

### DIFF
--- a/rasgotransforms/rasgotransforms/transforms/datespine/bigquery/datespine.sql
+++ b/rasgotransforms/rasgotransforms/transforms/datespine/bigquery/datespine.sql
@@ -1,7 +1,12 @@
+{% if start_timestamp is not defined or end_timestamp is not defined -%}
 {%- set min_max_query -%}
 select min(cast({{ date_col }} as date)) min_date, max(cast({{ date_col }} as date)) max_date from {{ source_table }}
 {% endset -%}
 {% set min_max_query_result = run_query(min_max_query) -%}
+{% if min_max_query_result is none -%}
+{{ raise_exception('start_timstamp and end_timestamp must be provided when no Data Warehouse connection is available')}}
+{% endif -%}
+{% endif -%}
 {% if start_timestamp is defined -%}
     {% set min_date = start_timestamp -%}
 {% else -%}

--- a/rasgotransforms/rasgotransforms/transforms/datespine/bigquery/datespine.sql
+++ b/rasgotransforms/rasgotransforms/transforms/datespine/bigquery/datespine.sql
@@ -1,40 +1,34 @@
-{% set min_max_query %}
+{%- set min_max_query -%}
 select min(cast({{ date_col }} as date)) min_date, max(cast({{ date_col }} as date)) max_date from {{ source_table }}
-{% endset %}
-{% set min_max_query_result = run_query(min_max_query) %}
-{% if start_timestamp is defined %}
-    {% set min_date = start_timestamp %}
-{% else %}
-    {% set min_date = min_max_query_result[min_max_query_result.columns[0]][0] %}
-{% endif %}
-{% if  end_timestamp is defined %}
-    {% set max_date = end_timestamp %}
-{% else %}
-    {% set max_date = min_max_query_result[min_max_query_result.columns[1]][0] %}
-{% endif %}
-{% set row_count_query %}
-select DATE_DIFF(cast('{{ min_date }}' as date), cast('{{ max_date }}' as date), {{ interval_type }})
-{% endset %}
-{% set row_count_query_results = run_query(row_count_query) %}
-{%- set row_count = row_count_query_results[row_count_query_results.columns[0]][0] -%}
-with date_spine as (
-    select
-           row_number() over (order by null) as interval_id,
-            DATE_ADD(
-                cast('{{ min_date }}' as timestamp),
-                INTERVAL interval_id - 1 {{ interval_type }}
-                ) as ts_ntz_interval_start,
-            DATE_ADD(
-                cast('{{ min_date }}' as timestamp)
-                INTERVAL interval_id {{ interval_type }}
-               ) as ts_ntz_interval_end
-from table (generator(rowcount => {{ row_count }}))
-    )
-select  {{ source_table }}.*,
-  date_spine.ts_ntz_interval_start as {{ date_col }}_spine_start,
-  date_spine.ts_ntz_interval_end as {{ date_col }}_spine_end
-from date_spine
-left join {{ source_table }} on
-    {{ source_table }}.{{ date_col }} >= date_spine.ts_ntz_interval_start
-    and
-    {{ source_table }}.{{ date_col }} < date_spine.ts_ntz_interval_end
+{% endset -%}
+{% set min_max_query_result = run_query(min_max_query) -%}
+{% if start_timestamp is defined -%}
+    {% set min_date = start_timestamp -%}
+{% else -%}
+    {% set min_date = min_max_query_result[min_max_query_result.columns[0]][0] -%}
+{% endif -%}
+{% if  end_timestamp is defined -%}
+    {% set max_date = end_timestamp -%}
+{% else -%}
+    {% set max_date = min_max_query_result[min_max_query_result.columns[1]][0] -%}
+{% endif -%}
+with calendar as (
+  select
+    date_day,
+    date_trunc(date_day, week) as date_week,
+    date_trunc(date_day, month) as date_month,
+    date_trunc(date_day, quarter) as date_quarter,
+    date_trunc(date_day, year) as date_year,
+    from unnest(generate_date_array('{{ min_date }}', '{{ max_date }}')) as date_day
+),
+spine as (
+    select distinct date_{{ interval_type }} as period
+    from calendar
+)
+select
+    cast(spine.period as timestamp) as {{ date_col }}_SPINE_START,
+    timestamp_add(cast(date_add(spine.period, INTERVAL 1 {{ interval_type }}) as timestamp), INTERVAL -1 second) as {{ date_col }}_SPINE_END,
+    {{ source_table }}.*
+from spine
+left outer join {{ source_table }} on 
+    cast(date_trunc(cast({{ source_table}}.{{ date_col }} as date), {{ interval_type }}) as date) = spine.period

--- a/rasgotransforms/rasgotransforms/transforms/datespine/snowflake/datespine.sql
+++ b/rasgotransforms/rasgotransforms/transforms/datespine/snowflake/datespine.sql
@@ -1,7 +1,12 @@
+{% if start_timestamp is not defined or end_timestamp is not defined -%}
 {%- set min_max_query -%}
 select min(cast({{ date_col }} as date)) min_date, max(cast({{ date_col }} as date)) max_date from {{ source_table }}
 {% endset -%}
 {% set min_max_query_result = run_query(min_max_query) -%}
+{% if min_max_query_result is none -%}
+{{ raise_exception('start_timstamp and end_timestamp must be provided when no Data Warehouse connection is available')}}
+{% endif -%}
+{% endif -%}
 {% if start_timestamp is defined -%}
     {% set min_date = start_timestamp -%}
 {% else -%}

--- a/rasgotransforms/rasgotransforms/transforms/datespine/snowflake/datespine.sql
+++ b/rasgotransforms/rasgotransforms/transforms/datespine/snowflake/datespine.sql
@@ -1,40 +1,48 @@
-{% set min_max_query %}
+{%- set min_max_query -%}
 select min(cast({{ date_col }} as date)) min_date, max(cast({{ date_col }} as date)) max_date from {{ source_table }}
-{% endset %}
-{% set min_max_query_result = run_query(min_max_query) %}
-{% if start_timestamp is defined %}
-    {% set min_date = start_timestamp %}
-{% else %}
-    {% set min_date = min_max_query_result[min_max_query_result.columns[0]][0] %}
-{% endif %}
-{% if  end_timestamp is defined %}
-    {% set max_date = end_timestamp %}
-{% else %}
-    {% set max_date = min_max_query_result[min_max_query_result.columns[1]][0] %}
-{% endif %}
-{% set row_count_query %}
-select datediff({{ interval_type }}, '{{ min_date }}'::timestamp_ntz, '{{ max_date }}'::timestamp_ntz)
-{% endset %}
-{% set row_count_query_results = run_query(row_count_query) %}
-{%- set row_count = row_count_query_results[row_count_query_results.columns[0]][0] -%}
-with date_spine as (
+{% endset -%}
+{% set min_max_query_result = run_query(min_max_query) -%}
+{% if start_timestamp is defined -%}
+    {% set min_date = start_timestamp -%}
+{% else -%}
+    {% set min_date = min_max_query_result[min_max_query_result.columns[0]][0] -%}
+{% endif -%}
+{% if  end_timestamp is defined -%}
+    {% set max_date = end_timestamp -%}
+{% else -%}
+    {% set max_date = min_max_query_result[min_max_query_result.columns[1]][0] -%}
+{% endif -%}
+{% set num_days = (max_date|string|todatetime - min_date|string|todatetime).days + 1 -%}
+with calendar as (
     select
-           row_number() over (order by null) as interval_id,
-            dateadd(
-               '{{ interval_type }}',
-               interval_id - 1,
-               '{{ min_date }}'::timestamp_ntz) as ts_ntz_interval_start,
-            dateadd(
-               '{{ interval_type }}',
-               interval_id,
-               '{{ min_date }}'::timestamp_ntz) as ts_ntz_interval_end
-from table (generator(rowcount => {{ row_count }}))
-    )
-select  {{ source_table }}.*,
-  date_spine.ts_ntz_interval_start as {{ date_col }}_spine_start,
-  date_spine.ts_ntz_interval_end as {{ date_col }}_spine_end
-from date_spine
-left join {{ source_table }} on
-    {{ source_table }}.{{ date_col }} >= date_spine.ts_ntz_interval_start
-    and
-    {{ source_table }}.{{ date_col }} < date_spine.ts_ntz_interval_end
+        row_number() over (order by null) as interval_id,
+        cast(dateadd(
+            'day',
+            interval_id-1,
+            '{{ min_date }}'::timestamp_ntz) as date) as date_day,
+        cast(date_trunc('week', date_day) as date) as date_week,
+        cast(date_trunc('month', date_day) as date) as date_month,
+        case
+            when month(date_day) in (1, 2, 3) then date_from_parts(year(date_day), 1, 1)
+            when month(date_day) in (4, 5, 6) then date_from_parts(year(date_day), 4, 1)
+            when month(date_day) in (7, 8, 9) then date_from_parts(year(date_day), 7, 1)
+            when month(date_day) in (10, 11, 12) then date_from_parts(year(date_day), 10, 1)
+        end as date_quarter,
+        cast(date_trunc('year', date_day) as date) as date_year
+    from table (generator(rowcount => {{ num_days }}))
+),
+spine as (
+    select distinct date_{{ interval_type }} as period
+    from calendar
+)
+select
+    cast(spine.period as timestamp) as {{ date_col }}_SPINE_START,
+    {%- if interval_type|lower == 'quarter' %}
+    dateadd('second', -1, dateadd('month',3, {{ date_col }}_SPINE_START)) as {{ date_col }}_SPINE_END,
+    {%- else %}
+    dateadd('second', -1, dateadd('{{ interval_type }}',1, {{ date_col }}_SPINE_START)) as {{ date_col }}_SPINE_END,
+    {%- endif %}
+    {{ source_table }}.*
+from spine
+left outer join {{ source_table }} on 
+    cast(date_trunc('{{ interval_type }}', cast({{ source_table}}.{{ date_col }} as date)) as date) = spine.period

--- a/rasgotransforms/rasgotransforms/transforms/datespine_groups/bigquery/datespine_groups.sql
+++ b/rasgotransforms/rasgotransforms/transforms/datespine_groups/bigquery/datespine_groups.sql
@@ -1,7 +1,12 @@
+{% if start_timestamp is not defined or end_timestamp is not defined -%}
 {%- set min_max_query -%}
 select min(cast({{ date_col }} as date)) min_date, max(cast({{ date_col }} as date)) max_date from {{ source_table }}
 {% endset -%}
 {% set min_max_query_result = run_query(min_max_query) -%}
+{% if min_max_query_result is none -%}
+{{ raise_exception('start_timstamp and end_timestamp must be provided when no Data Warehouse connection is available')}}
+{% endif -%}
+{% endif -%}
 {% if start_timestamp is defined -%}
     {% set min_date = start_timestamp -%}
 {% else -%}

--- a/rasgotransforms/rasgotransforms/transforms/datespine_groups/bigquery/datespine_groups.sql
+++ b/rasgotransforms/rasgotransforms/transforms/datespine_groups/bigquery/datespine_groups.sql
@@ -1,17 +1,34 @@
-{% set row_count_query %}
-select datediff(cast('{{ start_timestamp }}' as timestamp), cast('{{ end_timestamp }}' as timestamp), {{ interval_type }})
-{% endset %}
-{% set row_count_query_results = run_query(row_count_query) %}
-{% set row_count = row_count_query_results[row_count_query_results.columns[0]][0] %}
-
-WITH GLOBAL_SPINE AS (
-  SELECT
-    ROW_NUMBER() OVER (ORDER BY NULL) as INTERVAL_ID,
-    DATEADD(cast('{{ start_timestamp }}' as timestamp), INTERVAL (INTERVAL_ID - 1) {{ interval_type }}) as SPINE_START,
-    DATEADD(cast('{{ start_timestamp }}' as timestamp), INTERVAL INTERVAL_ID {{ interval_type }}) as SPINE_END
-  FROM TABLE (GENERATOR(ROWCOUNT => {{ row_count }}))
+{%- set min_max_query -%}
+select min(cast({{ date_col }} as date)) min_date, max(cast({{ date_col }} as date)) max_date from {{ source_table }}
+{% endset -%}
+{% set min_max_query_result = run_query(min_max_query) -%}
+{% if start_timestamp is defined -%}
+    {% set min_date = start_timestamp -%}
+{% else -%}
+    {% set min_date = min_max_query_result[min_max_query_result.columns[0]][0] -%}
+{% endif -%}
+{% if  end_timestamp is defined -%}
+    {% set max_date = end_timestamp -%}
+{% else -%}
+    {% set max_date = min_max_query_result[min_max_query_result.columns[1]][0] -%}
+{% endif -%}
+{% set row_count = (max_date|string|todatetime - min_date|string|todatetime).days + 1 -%}
+with calendar as (
+  select
+    date_day,
+    date_trunc(date_day, week) as date_week,
+    date_trunc(date_day, month) as date_month,
+    date_trunc(date_day, quarter) as date_quarter,
+    date_trunc(date_day, year) as date_year,
+    from unnest(generate_date_array('{{ min_date }}', '{{ max_date }}')) as date_day
+),
+GLOBAL_SPINE AS (
+  select
+    distinct date_{{ interval_type }} as SPINE_START,
+    date_add(date_{{ interval_type }}, INTERVAL 1 {{ interval_type }}) SPINE_END,
+  from calendar
 ), 
-GROUPS AS (
+CATEGORIES AS (
   SELECT 
     {% for col in group_by -%}
     {{ col }},
@@ -31,8 +48,8 @@ GROUP_SPINE AS (
     {%- endfor %}
     SPINE_START AS GROUP_START, 
     SPINE_END AS GROUP_END
-  FROM GROUPS G
-  CROSS JOIN LATERAL (
+  FROM CATEGORIES G
+  CROSS JOIN (
     SELECT
       SPINE_START, SPINE_END
     FROM GLOBAL_SPINE S

--- a/rasgotransforms/rasgotransforms/transforms/datespine_groups/snowflake/datespine_groups.sql
+++ b/rasgotransforms/rasgotransforms/transforms/datespine_groups/snowflake/datespine_groups.sql
@@ -1,7 +1,12 @@
+{% if start_timestamp is not defined or end_timestamp is not defined -%}
 {%- set min_max_query -%}
 select min(cast({{ date_col }} as date)) min_date, max(cast({{ date_col }} as date)) max_date from {{ source_table }}
 {% endset -%}
 {% set min_max_query_result = run_query(min_max_query) -%}
+{% if min_max_query_result is none -%}
+{{ raise_exception('start_timstamp and end_timestamp must be provided when no Data Warehouse connection is available')}}
+{% endif -%}
+{% endif -%}
 {% if start_timestamp is defined -%}
     {% set min_date = start_timestamp -%}
 {% else -%}


### PR DESCRIPTION
Big improvements for datespine:
- Big query version didn't work at all before, now it works
- num_rows is calculated from start and stop dates in the jinja with python instead of using runquery
- week periods now go back to the first day of the calendar week instead of just 7 days before whatever the min_date is
- added support for quarter time grain
- Made same changes to datespine_groups