### PR TITLE
it cant be this easy?

### DIFF
--- a/rasgotransforms/rasgotransforms/transforms/pivot/bigquery/pivot.sql
+++ b/rasgotransforms/rasgotransforms/transforms/pivot/bigquery/pivot.sql
@@ -29,11 +29,11 @@ PIVOT (
     FOR {{ value_column }} IN ( 
         {%- for val in distinct_vals %}
         {%- if val is string -%}
-            '{{ val }}'
+            '{{ val }}' {{ cleanse_name(val) }}
         {%- elif val is none -%}
-            NULL
+            NULL NULL_REC
         {%- else -%}
-            {{ val }}
+            {{ val }} {{ cleanse_name(val) }}
         {%- endif -%}
             {{', ' if not loop.last else ''}}
         {%- endfor -%}


### PR DESCRIPTION
Big problem we used to have in BigQuery pivot - we weren't aliasing the column names as we pivoted them out, because the template wasn't constructed in a friendly way to allow us to use `cleanse_name` (or so we thought). Turns out, you can functionally alias column names in the `IN()` clause, meaning we can rock with `cleanse_name` in this template and stop seeing bugs.