### PR TITLE
Fix column_name

### DIFF
--- a/rasgotransforms/rasgotransforms/snippets/column.sql
+++ b/rasgotransforms/rasgotransforms/snippets/column.sql
@@ -1,1 +1,1 @@
-{{ column_name }}
+{{ column }}


### PR DESCRIPTION
The column code snippet appends a random "_name" to the end of jinja arguments in the custom SQL template form. This change fixes that.