### PR TITLE
Universal filter macro

### DIFF
--- a/rasgotransforms/rasgotransforms/macros/bigquery/aggregate_metrics.sql
+++ b/rasgotransforms/rasgotransforms/macros/bigquery/aggregate_metrics.sql
@@ -54,7 +54,8 @@ with
             {{ column }}{{ ',' if not loop.last }}
             {% endfor %}
         from {{ source_table if not (distinct_values and dimensions) else 'combined_dimensions'}}
-            {{ filter_statement | indent }}
+        where ({{ time_dimension }} >= '{{ start_date }}' and {{ time_dimension }} <= '{{ end_date }}') and
+            {{ filter_statement | indent(12) }}
     ),
     {% if distinct_values and dimensions %}
     {% set dimensions=['dimensions'] %}
@@ -219,7 +220,8 @@ buckets as (
     from
         {{ source_table if not (distinct_values and dimensions) else 'combined_dimensions'}}
         cross join edges
-    {{ filter_statement | indent }}
+    where
+        {{ filter_statement | indent(8) }}
 ),
 source_query as (
     select
@@ -361,7 +363,8 @@ source_query as (
         {{ column }}{{ ',' if not loop.last }}
         {% endfor %}
     from {{ source_table if not (distinct_values and dimensions) else 'combined_dimensions'}}
-    {{ filter_statement }}
+    where
+        {{ filter_statement | indent(8) }}
 ),
 {% if distinct_values and dimensions %}
 {% set dimensions = ['dimensions'] %}

--- a/rasgotransforms/rasgotransforms/macros/distinct_values.sql
+++ b/rasgotransforms/rasgotransforms/macros/distinct_values.sql
@@ -21,7 +21,8 @@
         sum(0) as vals
         {% endif %}
     from {{ source_table }}
-        {{ filter_statement }}
+    where
+        {{ filter_statement | indent }}
     group by 1
     order by vals desc
     limit {{ max_vals + 1}}
@@ -62,7 +63,8 @@
         ) as dimensions,
         coalesce({{ target_metric.agg_method|lower|replace('_', '')|replace('distinct', '') }}({{ 'distinct ' if 'distinct ' in target_metric.agg_method|lower else ''}}{{ target_metric.column }}), 0) as vals
     from distinct_vals_source_query
-        {{ filter_statement }}
+    where
+        {{ filter_statement | indent}}
     group by 1
     order by vals desc
     limit {{ max_vals + 1}}

--- a/rasgotransforms/rasgotransforms/macros/expression_metrics.sql
+++ b/rasgotransforms/rasgotransforms/macros/expression_metrics.sql
@@ -59,7 +59,7 @@ with
             source_table=metric.source_table,
             filters=metric.filters,
             distinct_values=distinct_values
-            ) | indent
+            ) | indent(8)
         }}
     ),
 {% endfor %}

--- a/rasgotransforms/rasgotransforms/macros/filter.sql
+++ b/rasgotransforms/rasgotransforms/macros/filter.sql
@@ -5,12 +5,20 @@
 {% else %}
 {% set logical_operator = namespace(value='AND') %}
 {% for filter in filters %}
-    {% if filter is mapping and 'compoundBoolean' in filter %}
-        {% set logical_operator.value = filter['compoundBoolean'] %}
+    {% if filter is not string %}
+        {% if filter is not mapping %}
+            {% set filter = dict(filter) %}
+        {% endif %}
+        {% if filter is mapping and 'compoundBoolean' in filter and filter['compoundBoolean'] %}
+            {% set logical_operator.value = filter['compoundBoolean'] %}
+        {% endif %}
     {% endif %}
 {% endfor %}
 (
     {% for filter in filters %}
+    {% if filter is not string and filter is not mapping %}
+    {% set filter = dict(filter) %}
+    {% endif %}
     {% if filter is not mapping %}
     {{ logical_operator.value + ' ' if not loop.first }}{{ filter }}
     {% elif filter.operator|upper == 'CONTAINS' %}

--- a/rasgotransforms/rasgotransforms/macros/filter.sql
+++ b/rasgotransforms/rasgotransforms/macros/filter.sql
@@ -9,40 +9,19 @@
         {% set logical_operator.value = filter['compoundBoolean'] %}
     {% endif %}
 {% endfor %}
-where
+(
     {% for filter in filters %}
     {% if filter is not mapping %}
-    {{ logical_operator.value if not loop.first}} {{ filter }}
+    {{ logical_operator.value + ' ' if not loop.first }}{{ filter }}
     {% elif filter.operator|upper == 'CONTAINS' %}
-    {{ logical_operator.value if not loop.first}} {{ filter.operator }}({{ filter.columnName }}, {{ filter.comparisonValue }})
+    {{ logical_operator.value + ' ' if not loop.first }}{{ filter.operator }}({{ filter.columnName }}, {{ filter.comparisonValue }})
     {% else %}
-    {{ logical_operator.value if not loop.first}} {{ filter.columnName }} {{ filter.operator }} {{ filter.comparisonValue }}
+    {{ logical_operator.value + ' ' if not loop.first }}{{ filter.columnName }} {{ filter.operator }} {{ filter.comparisonValue }}
     {% endif %}
     {% endfor %}
+)
 {% endif %}
+{% else %}
+true
 {% endif %}
-{% endmacro %}
-
-
-{% macro get_metric_filter_statement(x_axis, start_date, end_date, filters) %}
-{% set logical_operator = namespace(value='AND') %}
-{% for filter in filters %}
-{% if filter is mapping and 'compoundBoolean' in filter %}
-    {% set logical_operator.value = filter['compoundBoolean'] %}
-{% endif %}
-{% endfor %}
-where ({{ x_axis }} >= '{{ start_date }}' AND {{ x_axis }} <= '{{ end_date }}') {{ 'AND' if filters }}
-    {% if filters %}
-    (
-    {% for filter in filters %}
-    {% if filter is not mapping %}
-    {{ logical_operator.value if not loop.first}} {{ filter }}
-    {% elif filter.operator|upper == 'CONTAINS' %}
-    {{ logical_operator.value if not loop.first}} {{ filter.operator }}({{ filter.columnName }}, {{ filter.comparisonValue }})
-    {% else %}
-    {{ logical_operator.value if not loop.first}} {{ filter.columnName }} {{ filter.operator }} {{ filter.comparisonValue }}
-    {% endif %}
-    {% endfor %}
-    )
-    {% endif %}
 {% endmacro %}

--- a/rasgotransforms/rasgotransforms/transforms/filter/filter.sql
+++ b/rasgotransforms/rasgotransforms/transforms/filter/filter.sql
@@ -1,3 +1,4 @@
+{% from 'filter.sql' import get_filter_statement %}
 {% if items is not defined %}
     {% if filter_statements is not defined %}
         {{ raise_exception('items is empty: there are no filters to apply') }}
@@ -5,25 +6,8 @@
         {% set items = filter_statements %}
     {% endif %}
 {% endif %}
-{% set logical_operator = namespace(value='AND') %}
-{% for filter_block in items %}
-    {% if filter_block is mapping and 'compoundBoolean' in filter_block %}
-        {% set logical_operator.value = filter_block['compoundBoolean'] %}
-    {% endif %}
-{% endfor %}
 
-SELECT *
-FROM {{ source_table }}
-WHERE
-{% for filter_block in items %}
-{% set oloop = loop %}
-    {% if filter_block is not mapping %}
-    {{ logical_operator.value if not loop.first}} {{ filter_block }}
-    {% else %}
-        {% if filter_block['operator'] == 'CONTAINS' %}
-    {{ logical_operator.value if not loop.first}} {{ filter_block['operator'] }}({{ filter_block['columnName'] }}, {{ filter_block['comparisonValue'] }})
-        {% else %}
-    {{ logical_operator.value if not loop.first}} {{ filter_block['columnName'] }} {{ filter_block['operator'] }} {{ filter_block['comparisonValue'] }}
-        {% endif %}
-    {% endif %}
-{% endfor %}
+select *
+from {{ source_table }}
+where true and
+    {{ get_filter_statement(items) | indent }}

--- a/rasgotransforms/rasgotransforms/transforms/metric/metric.sql
+++ b/rasgotransforms/rasgotransforms/transforms/metric/metric.sql
@@ -10,8 +10,6 @@
 {% set alias = 'metric_value' if not alias else alias %}
 {% set max_num_groups = max_num_groups if max_num_groups is defined else 10 %}
 {% set filters = filters if filters is defined else [] %}
-{% do filters.append({'columnName': time_dimension, 'operator': '>=', 'comparisonValue': "'" + start_date + "'" }) %}
-{% do filters.append({'columnName': time_dimension, 'operator': '<=', 'comparisonValue': "'" + end_date + "'" }) %}
 
 {% if type|lower == 'expression' %}
 

--- a/rasgotransforms/rasgotransforms/version.py
+++ b/rasgotransforms/rasgotransforms/version.py
@@ -1,4 +1,4 @@
 """
 Package version for pypi
 """
-__version__ = "2.2.2a1"
+__version__ = "2.2.2"

--- a/rasgotransforms/rasgotransforms/version.py
+++ b/rasgotransforms/rasgotransforms/version.py
@@ -1,4 +1,4 @@
 """
 Package version for pypi
 """
-__version__ = "2.2.1"
+__version__ = "2.2.2a1"


### PR DESCRIPTION
This creates a macro `get_filter_statement` which accepts a list of filter objects which can either be a raw filter string or a list of objects with `columnName`, `operator`, `comparisonValue`, and optionally `compoundBoolean`

The macro returns a filter statement wrapped in parenthesis or `true` if the list is empty, but does not include the 'where' statement. This way, it can be used anywhere a logical condition is used, not just in a where clause.

Input:
```
[
  {"columnName": "COLOR", "operator": "=", "comparisonValue": "'Black'", "compoundBoolean": "OR"}, # Normal filter object
  "SALESTERRITORYKEY IN (1, 2, 3)",                                                                # 'Advanced' filter statement
]
```

Output:
```
(
  COLOR = 'Black'
  OR SALESTERRITORYKEY IN (1, 2, 3)
)
```


The macro is used in 
- plot
- metric
- filter transform