### PR TITLE
make RasgoEnvironment params optional

### DIFF
--- a/rasgotransforms/rasgotransforms/render/environment.py
+++ b/rasgotransforms/rasgotransforms/render/environment.py
@@ -14,8 +14,10 @@ from rasgotransforms.main import DataWarehouse
 
 
 class RasgoEnvironment(Environment):
-    def __init__(self, dw_type: str, run_query: Callable, *args, **kwargs):
+    def __init__(self, run_query: Optional[Callable] = None, dw_type: Optional[str] = None, *args, **kwargs):
         super().__init__(*args, extensions=self.rasgo_extensions, loader=RasgoLoader(), **kwargs)
+        if not dw_type:
+            dw_type = 'snowflake'
         self._dw_type = DataWarehouse(dw_type)
         for filter_name, method in self.rasgo_filters.items():
             self.filters[filter_name] = method

--- a/rasgotransforms/rasgotransforms/version.py
+++ b/rasgotransforms/rasgotransforms/version.py
@@ -1,4 +1,4 @@
 """
 Package version for pypi
 """
-__version__ = "2.2.5"
+__version__ = "2.2.6"


### PR DESCRIPTION
Makes `run_query` default to none and `dw_type` default to 'snowflake' if not set.