### PR TITLE
'All' time time grain fix

### DIFF
--- a/rasgotransforms/rasgotransforms/macros/bigquery/aggregate_metrics.sql
+++ b/rasgotransforms/rasgotransforms/macros/bigquery/aggregate_metrics.sql
@@ -63,14 +63,14 @@ with
     {% if time_grain|lower == 'all' %}
     spine as (
         select
-            cast('{{ start_date }}' as timestamp) as {{ time_dimension }}_min,
-            cast('{{ end_date }}' as timestamp) as {{ time_dimension }}_max
+            cast('{{ start_date }}' as timestamp) as period_min,
+            cast('{{ end_date }}' as timestamp) as period_max
     ),
     joined as (select * from source_query cross join spine),
     tidy_data as (
         select
-            {{ time_dimension }}_min,
-            {{ time_dimension }}_max,
+            period_min,
+            period_max,
             {% for dimension in dimensions %}
             {{ dimension }},
             {% endfor %}

--- a/rasgotransforms/rasgotransforms/macros/bigquery/pivot.sql
+++ b/rasgotransforms/rasgotransforms/macros/bigquery/pivot.sql
@@ -24,39 +24,38 @@ with
         pivot (
             sum( {{ metric_name }} ) as {{ metric_name }}
             for dimensions in (
-                {%- for val in distinct_values %}
-                {%- set column_name = metric_name + '_' + (val|string) -%}
-                {%- do column_names.append(column_name) -%}
-                {%- if val is string -%}
+                {% for val in distinct_values %}
+                {% set column_name = metric_name + '_' + (val|string) %}
+                {% do column_names.append(column_name) %}
+                {% if val is string %}
                 '{{ val }}'
-                {%- else -%}
+                {% else %}
                 {{ val }}
-                {%- endif -%}
+                {% endif %}
                 {{', ' if not loop.last else ''}}
-                {%- endfor -%}
+                {% endfor %}
             )
         )
     ),
-    {%- endfor %}
-    {%- endfor %}
+    {% endfor %}
     pivoted as (
         select *
         from pivoted__{{ metric_names[0] }}
-            {%- for i in range(1, metric_names|length) %}
+            {% for i in range(1, metric_names|length) %}
             left join pivoted__{{ metric_names[i] }}
                 on x_min_{{ metric_names[0] }} = x_min_{{ metric_names[i] }}
                 and x_max_{{ metric_names[0] }} = x_max_{{ metric_names[i] }}
-            {%- endfor %}
+            {% endfor %}
     )
 select
-    {%- if axis_type == 'categorical' %}
+    {% if axis_type == 'categorical' %}
     x_min_{{ metric_names[0] }} as {{ x_axis }},
-    {%- else %}
+    {% else %}
     x_min_{{ metric_names[0] }} as {{ x_axis }}_min,
     x_max_{{ metric_names[0] }} as {{ x_axis }}_max,
-    {%- endif %}
-    {%- for column_name in column_names %}
+    {% endif %}
+    {% for column_name in column_names %}
     {{ column_name }}{{ ',' if not loop.last }}
-    {%- endfor %}
+    {% endfor %}
 from pivoted order by 1 {{ x_axis_order if x_axis_order }}
 {% endmacro %}

--- a/rasgotransforms/rasgotransforms/macros/snowflake/aggregate_metrics.sql
+++ b/rasgotransforms/rasgotransforms/macros/snowflake/aggregate_metrics.sql
@@ -58,14 +58,14 @@ with
     {% if time_grain | lower == "all" %}
     spine as (
         select
-            cast('{{ start_date }}' as timestamp_ntz) as {{ time_dimension }}_min,
-            cast('{{ end_date }}' as timestamp_ntz) as {{ time_dimension }}_max
+            cast('{{ start_date }}' as timestamp_ntz) as period_min,
+            cast('{{ end_date }}' as timestamp_ntz) as period_max
     ),
     joined as (select * from source_query cross join spine),
     tidy_data as (
         select
-            {{ time_dimension }}_min,
-            {{ time_dimension }}_max,
+            period_min,
+            period_max,
             {% for dimension in dimensions %}
             {{ dimension }},
             {% endfor %}

--- a/rasgotransforms/rasgotransforms/version.py
+++ b/rasgotransforms/rasgotransforms/version.py
@@ -1,4 +1,4 @@
 """
 Package version for pypi
 """
-__version__ = "2.2.6"
+__version__ = "2.2.7"


### PR DESCRIPTION
The 'all' time grain is broken when adding dimensions due to the column name being assigned incorrectly in the macro, this fixes it. It also fixes a jinja syntax bug when pivoting out the dimensions for bigquery.