### PR TITLE
change filter macro to take snake and camel case

### DIFF
--- a/docs/filter.md
+++ b/docs/filter.md
@@ -24,7 +24,7 @@ ds2 = ds.filter(items=['PRODUCTKEY < 500'])
 ds2.preview()
 
 # full filtering with a column, operator, and comparison value
-ds3 = ds.filter(items=[{'columnName':'PRODUCTKEY', 'operator':'>', 'comparisonValue':'101'}])
+ds3 = ds.filter(items=[{'column_name':'PRODUCTKEY', 'operator':'>', 'comparison_value':'101'}])
 ds3.preview()
 ```
 

--- a/rasgotransforms/rasgotransforms/accelerators/baby_name_analysis.yaml
+++ b/rasgotransforms/rasgotransforms/accelerators/baby_name_analysis.yaml
@@ -52,9 +52,9 @@ operations:
     transform_name: filter
     transform_arguments:
       items:
-        - columnName: BABYNAME
+        - column_name: BABYNAME
           operator: '='
-          comparisonValue: "'{{ baby_name }}'"
+          comparison_value: "'{{ baby_name }}'"
       source_table: '{{convert_to_percent }}'
   most_popular_state:
     transform_name: apply

--- a/rasgotransforms/rasgotransforms/accelerators/gaps_check.yaml
+++ b/rasgotransforms/rasgotransforms/accelerators/gaps_check.yaml
@@ -47,9 +47,9 @@ operations:
     transform_name: filter
     transform_arguments:
       items:
-      - columnName: LAG_ISLAND_START_DATETIME__1
+      - column_name: LAG_ISLAND_START_DATETIME__1
         operator: is not NULL
-        comparisonValue: ''
+        comparison_value: ''
       source_table: '{{lag}}'
   datediff:
     transform_name: datediff

--- a/rasgotransforms/rasgotransforms/accelerators/plg_funnel.yaml
+++ b/rasgotransforms/rasgotransforms/accelerators/plg_funnel.yaml
@@ -28,21 +28,21 @@ operations:
     transform_name: filter
     transform_arguments:
       items:
-      - columnName: IS_DELETED
+      - column_name: IS_DELETED
         operator: '='
-        comparisonValue: 'false'
+        comparison_value: 'false'
       source_table: '{{opportunities}}'
   getclosedwon:
     description: Keep only those opportunities that were closed won in Salesforce
     transform_name: filter
     transform_arguments:
       items:
-      - columnName: IS_DELETED
+      - column_name: IS_DELETED
         operator: '='
-        comparisonValue: 'false'
-      - columnName: IS_WON
+        comparison_value: 'false'
+      - column_name: IS_WON
         operator: '='
-        comparisonValue: 'true'
+        comparison_value: 'true'
       source_table: '{{opportunities}}'
   createweekly:
     description: Create weekly variable
@@ -104,18 +104,18 @@ operations:
     transform_name: filter
     transform_arguments:
       items:
-      - columnName: ORG_TYPE
+      - column_name: ORG_TYPE
         operator: '='
-        comparisonValue: '''ENTERPRISE'''
+        comparison_value: '''ENTERPRISE'''
       source_table: '{{weeklyusers}}'
   plgweeklyusers:
     description: keep free users
     transform_name: filter
     transform_arguments:
       items:
-      - columnName: ORG_TYPE
+      - column_name: ORG_TYPE
         operator: <>
-        comparisonValue: '''ENTERPRISE'''
+        comparison_value: '''ENTERPRISE'''
       source_table: '{{weeklyusers}}'
   plgidweeklyrepeats:
     description: Create variable to record next week PLG user uses product if repeats

--- a/rasgotransforms/rasgotransforms/macros/filter.sql
+++ b/rasgotransforms/rasgotransforms/macros/filter.sql
@@ -19,18 +19,18 @@
     {% if filter is not string and filter is not mapping %}
     {% set filter = dict(filter) %}
     {% endif %}
-    {% if 'column_name' in filter %}
-        {% do filter.__setitem__('columnName', filter.column_name) %}
+    {% if 'columnName' in filter %}
+        {% do filter.__setitem__('column_name', filter.columnName) %}
     {% endif %}
-    {% if 'comparison_value' in filter %}
-        {% do filter.__setitem__('comparisonValue', filter.comparison_value) %}
+    {% if 'comparisonValue' in filter %}
+        {% do filter.__setitem__('comparison_value', filter.comparisonValue) %}
     {% endif %}
     {% if filter is not mapping %}
     {{ logical_operator.value + ' ' if not loop.first }}{{ filter }}
     {% elif filter.operator|upper == 'CONTAINS' %}
-    {{ logical_operator.value + ' ' if not loop.first }}{{ filter.columnName }} like '%{{ filter.comparisonValue }}%'
+    {{ logical_operator.value + ' ' if not loop.first }}{{ filter.column_name }} like '%{{ filter.comparison_value }}%'
     {% else %}
-    {{ logical_operator.value + ' ' if not loop.first }}{{ filter.columnName }} {{ filter.operator }} {{ filter.comparisonValue }}
+    {{ logical_operator.value + ' ' if not loop.first }}{{ filter.column_name }} {{ filter.operator }} {{ filter.comparison_value }}
     {% endif %}
     {% endfor %}
 )

--- a/rasgotransforms/rasgotransforms/macros/filter.sql
+++ b/rasgotransforms/rasgotransforms/macros/filter.sql
@@ -19,6 +19,12 @@
     {% if filter is not string and filter is not mapping %}
     {% set filter = dict(filter) %}
     {% endif %}
+    {% if 'column_name' in filter %}
+        {% do filter.__setitem__('columnName', filter.column_name) %}
+    {% endif %}
+    {% if 'comparison_value' in filter %}
+        {% do filter.__setitem__('comparisonValue', filter.comparison_value) %}
+    {% endif %}
     {% if filter is not mapping %}
     {{ logical_operator.value + ' ' if not loop.first }}{{ filter }}
     {% elif filter.operator|upper == 'CONTAINS' %}

--- a/rasgotransforms/rasgotransforms/snippets/filter_list.sql
+++ b/rasgotransforms/rasgotransforms/snippets/filter_list.sql
@@ -13,9 +13,9 @@
     {% if filter is not mapping %}
     {{ filters.logical_operator + ' ' if not loop.first }}{{ filter }}
     {% elif filter.operator|upper == 'CONTAINS' %}
-    {{ filters.logical_operator.value + ' ' if not loop.first }}{{ filter.columnName }} like '%{{ filter.comparisonValue }}%'
+    {{ filters.logical_operator.value + ' ' if not loop.first }}{{ filter.column_name }} like '%{{ filter.comparison_value }}%'
     {% else %}
-    {{ filters.logical_operator + ' ' if not loop.first }}{{ filter.columnName }} {{ filter.operator }} {{ filter.comparisonValue }}
+    {{ filters.logical_operator + ' ' if not loop.first }}{{ filter.column_name }} {{ filter.operator }} {{ filter.comparison_value }}
     {% endif %}
     {% endfor %}
 )

--- a/rasgotransforms/rasgotransforms/tests/transforms/plot/plot_test.py
+++ b/rasgotransforms/rasgotransforms/tests/transforms/plot/plot_test.py
@@ -29,11 +29,11 @@ class TestPlotTransform:
             'metrics': {'SALESAMOUNT': ['SUM', 'AVG']},
             'filters': [
                 {
-                    'columnName': 'UNITPRICE',
+                    'column_name': 'UNITPRICE',
                     'operator': '>=',
-                    'comparisonValue': 1,
+                    'comparison_value': 1,
                 },
-                {'columnName': 'COLOR', 'operator': '=', 'comparisonValue': "'Black'", 'compoundBoolean': 'OR'},
+                {'column_name': 'COLOR', 'operator': '=', 'comparison_value': "'Black'", 'compoundBoolean': 'OR'},
             ],
         }
         environment = RasgoEnvironment(dw_type=dw_type, run_query=partial(run_query, dw_type=dw_type))
@@ -122,9 +122,9 @@ class TestPlotTransform:
             'metrics': {'SALESAMOUNT': ['SUM', 'AVG']},
             'filters': [
                 {
-                    'columnName': 'UNITPRICE',
+                    'column_name': 'UNITPRICE',
                     'operator': '>=',
-                    'comparisonValue': 1,
+                    'comparison_value': 1,
                 }
             ],
         }
@@ -179,9 +179,9 @@ class TestPlotTransform:
             'metrics': {'SALESAMOUNT': ['SUM', 'AVG']},
             'filters': [
                 {
-                    'columnName': 'UNITPRICE',
+                    'column_name': 'UNITPRICE',
                     'operator': '>=',
-                    'comparisonValue': 1,
+                    'comparison_value': 1,
                 }
             ],
         }

--- a/rasgotransforms/rasgotransforms/transforms/filter/filter.yaml
+++ b/rasgotransforms/rasgotransforms/transforms/filter/filter.yaml
@@ -19,5 +19,5 @@ example_code: |
   ds2.preview()
 
   # full filtering with a column, operator, and comparison value
-  ds3 = ds.filter(items=[{'columnName':'PRODUCTKEY', 'operator':'>', 'comparisonValue':'101'}])
+  ds3 = ds.filter(items=[{'column_name':'PRODUCTKEY', 'operator':'>', 'comparison_value':'101'}])
   ds3.preview()

--- a/rasgotransforms/rasgotransforms/transforms/heatmap/bigquery/heatmap.sql
+++ b/rasgotransforms/rasgotransforms/transforms/heatmap/bigquery/heatmap.sql
@@ -51,9 +51,9 @@ BUCKETS AS (
                   {{ filter_block }}
               {%- else -%}
                   {%- if filter_block['operator'] == 'CONTAINS' -%}
-                      {{ filter_block['operator'] }}({{ filter_block['columnName'] }}, {{ filter_block['comparisonValue'] }})
+                      {{ filter_block['operator'] }}({{ filter_block['column_name'] }}, {{ filter_block['comparison_value'] }})
                   {%- else -%}
-                      {{ filter_block['columnName'] }} {{ filter_block['operator'] }} {{ filter_block['comparisonValue'] }}
+                      {{ filter_block['column_name'] }} {{ filter_block['operator'] }} {{ filter_block['comparison_value'] }}
                   {%- endif -%}
               {%- endif -%}
         {%- endfor -%}

--- a/rasgotransforms/rasgotransforms/transforms/heatmap/heatmap.sql
+++ b/rasgotransforms/rasgotransforms/transforms/heatmap/heatmap.sql
@@ -44,9 +44,9 @@ BUCKETS AS (
                   {{ filter_block }}
               {%- else -%}
                   {%- if filter_block['operator'] == 'CONTAINS' -%}
-                      {{ filter_block['operator'] }}({{ filter_block['columnName'] }}, {{ filter_block['comparisonValue'] }})
+                      {{ filter_block['operator'] }}({{ filter_block['column_name'] }}, {{ filter_block['comparison_value'] }})
                   {%- else -%}
-                      {{ filter_block['columnName'] }} {{ filter_block['operator'] }} {{ filter_block['comparisonValue'] }}
+                      {{ filter_block['column_name'] }} {{ filter_block['operator'] }} {{ filter_block['comparison_value'] }}
                   {%- endif -%}
               {%- endif -%}
         {%- endfor -%}

--- a/rasgotransforms/rasgotransforms/transforms/histogram/histogram.sql
+++ b/rasgotransforms/rasgotransforms/transforms/histogram/histogram.sql
@@ -19,9 +19,9 @@ FROM
                 {{ filter_block }}
             {%- else -%}
                 {%- if filter_block['operator'] == 'CONTAINS' -%}
-                    {{ filter_block['operator'] }}({{ filter_block['columnName'] }}, {{ filter_block['comparisonValue'] }})
+                    {{ filter_block['operator'] }}({{ filter_block['column_name'] }}, {{ filter_block['comparison_value'] }})
                 {%- else -%}
-                    {{ filter_block['columnName'] }} {{ filter_block['operator'] }} {{ filter_block['comparisonValue'] }}
+                    {{ filter_block['column_name'] }} {{ filter_block['operator'] }} {{ filter_block['comparison_value'] }}
                 {%- endif -%}
             {%- endif -%}
     {%- endfor -%}

--- a/rasgotransforms/rasgotransforms/transforms/join/join.sql
+++ b/rasgotransforms/rasgotransforms/transforms/join/join.sql
@@ -36,9 +36,9 @@ FROM {{ source_table }} as t1
                 {{ filter_block }}
             {%- else -%}
                 {%- if filter_block['operator'] == 'CONTAINS' -%}
-                    {{ filter_block['operator'] }}({{ filter_block['columnName'] }}, {{ filter_block['comparisonValue'] }})
+                    {{ filter_block['operator'] }}({{ filter_block['column_name'] }}, {{ filter_block['comparison_value'] }})
                 {%- else -%}
-                    {{ filter_block['columnName'] }} {{ filter_block['operator'] }} {{ filter_block['comparisonValue'] }}
+                    {{ filter_block['column_name'] }} {{ filter_block['operator'] }} {{ filter_block['comparison_value'] }}
                 {%- endif -%}
             {%- endif -%}
     {%- endfor -%}

--- a/rasgotransforms/rasgotransforms/transforms/query/bigquery/query.sql
+++ b/rasgotransforms/rasgotransforms/transforms/query/bigquery/query.sql
@@ -13,9 +13,9 @@ filtered as (
     {%- if filter is not mapping %}
         {{ filter }}
     {%- elif filter.operator|upper == 'CONTAINS' %}
-        {{ filter.operator }}({{ filter.columnName }}, {{ filter.comparisonValue }})
+        {{ filter.operator }}({{ filter.column_name }}, {{ filter.comparison_value }})
     {%- else %}
-        {{ filter.columnName }} {{ filter.operator }} {{ filter.comparisonValue }}
+        {{ filter.column_name }} {{ filter.operator }} {{ filter.comparison_value }}
     {%- endif %}
     {{ " AND " if not loop.last else "" }}
 {%- endfor %}

--- a/rasgotransforms/rasgotransforms/transforms/query/snowflake/query.sql
+++ b/rasgotransforms/rasgotransforms/transforms/query/snowflake/query.sql
@@ -13,9 +13,9 @@ filtered as (
     {%- if filter is not mapping %}
         {{ filter }}
     {%- elif filter.operator|upper == 'CONTAINS' %}
-        {{ filter.operator }}({{ filter.columnName }}, {{ filter.comparisonValue }})
+        {{ filter.operator }}({{ filter.column_name }}, {{ filter.comparison_value }})
     {%- else %}
-        {{ filter.columnName }} {{ filter.operator }} {{ filter.comparisonValue }}
+        {{ filter.column_name }} {{ filter.operator }} {{ filter.comparison_value }}
     {%- endif %}
     {{ " AND " if not loop.last else "" }}
 {%- endfor %}

--- a/rasgotransforms/rasgotransforms/transforms/sample/sample.sql
+++ b/rasgotransforms/rasgotransforms/transforms/sample/sample.sql
@@ -14,9 +14,9 @@ WITH filtered AS (
             {{ filter_block }}
         {%- else -%}
             {%- if filter_block['operator'] == 'CONTAINS' -%}
-                {{ filter_block['operator'] }}({{ filter_block['columnName'] }}, {{ filter_block['comparisonValue'] }})
+                {{ filter_block['operator'] }}({{ filter_block['column_name'] }}, {{ filter_block['comparison_value'] }})
             {%- else -%}
-                {{ filter_block['columnName'] }} {{ filter_block['operator'] }} {{ filter_block['comparisonValue'] }}
+                {{ filter_block['column_name'] }} {{ filter_block['operator'] }} {{ filter_block['comparison_value'] }}
             {%- endif -%}
         {%- endif -%}
     {%- endfor -%}

--- a/rasgotransforms/rasgotransforms/transforms/table/table.sql
+++ b/rasgotransforms/rasgotransforms/transforms/table/table.sql
@@ -14,9 +14,9 @@ FROM {{ source_table }}
             {{ filter_block }}
         {%- else -%}
             {%- if filter_block['operator'] == 'CONTAINS' -%}
-                {{ filter_block['operator'] }}({{ filter_block['columnName'] }}, {{ filter_block['comparisonValue'] }})
+                {{ filter_block['operator'] }}({{ filter_block['column_name'] }}, {{ filter_block['comparison_value'] }})
             {%- else -%}
-                {{ filter_block['columnName'] }} {{ filter_block['operator'] }} {{ filter_block['comparisonValue'] }}
+                {{ filter_block['column_name'] }} {{ filter_block['operator'] }} {{ filter_block['comparison_value'] }}
             {%- endif -%}
         {%- endif -%}
     {%- endfor -%}

--- a/rasgotransforms/rasgotransforms/version.py
+++ b/rasgotransforms/rasgotransforms/version.py
@@ -1,4 +1,4 @@
 """
 Package version for pypi
 """
-__version__ = "2.2.15a2"
+__version__ = "2.3.0"

--- a/rasgotransforms/rasgotransforms/version.py
+++ b/rasgotransforms/rasgotransforms/version.py
@@ -1,4 +1,4 @@
 """
 Package version for pypi
 """
-__version__ = "2.2.15"
+__version__ = "2.2.15a2"

--- a/rasgotransforms/rasgotransforms/version.py
+++ b/rasgotransforms/rasgotransforms/version.py
@@ -1,4 +1,4 @@
 """
 Package version for pypi
 """
-__version__ = "2.2.14"
+__version__ = "2.2.15"


### PR DESCRIPTION
This is needed because sometimes the UI passes the transform args directly, which may include metric definitions that will come camel case, but other times metric definitions passed as args from the API are snake case