### PR TITLE
Publish VIZ operation type 

### DIFF
--- a/python/publish_transforms.py
+++ b/python/publish_transforms.py
@@ -48,6 +48,7 @@ def publish_transforms(rasgo_api_key: str, rasgo_domain: str) -> None:
 
         # Load/parse needed transform data from YAML
         transform_description = transform_yaml.get('description')
+        operation_type = transform_yaml.get('operation_type', 'SQL')
         transform_source_code_variants = utils.get_transform_source_code_all_dws(transform_name=transform_name)
         transform_tags = utils.listify_tags(tags=transform_yaml.get('tags'))
         transform_args = utils.parse_transform_args_from_yaml(transform_yaml)
@@ -68,6 +69,7 @@ def publish_transforms(rasgo_api_key: str, rasgo_domain: str) -> None:
                 try:
                     rasgo.create.transform(
                         name=transform_name,
+                        operation_type=operation_type,
                         source_code=source_code,
                         arguments=transform_args,
                         description=transform_description,
@@ -93,6 +95,7 @@ def publish_transforms(rasgo_api_key: str, rasgo_domain: str) -> None:
                     tags=transform_tags,
                     transform_type=transform_type,
                     context=transform_context,
+                    operation_type=operation_type,
                 ):
                     print(
                         f"Versioning transform '{transform_name}'. Updates found "
@@ -103,6 +106,7 @@ def publish_transforms(rasgo_api_key: str, rasgo_domain: str) -> None:
                         rasgo.create.transform(
                             name=transform_name,
                             source_code=source_code,
+                            operation_type=operation_type,
                             arguments=transform_args,
                             description=transform_description,
                             tags=transform_tags,

--- a/python/utils.py
+++ b/python/utils.py
@@ -104,6 +104,7 @@ def transform_needs_versioning(
     tags: List[str],
     transform_type: str,
     context: Optional[Dict[str, Any]],
+    operation_type: str,
 ) -> bool:
     """
     Return true if any of the attributes for the transform has
@@ -125,6 +126,7 @@ def transform_needs_versioning(
         or _transform_args_have_changed(transform, arguments)
         or transform_type != transform.type
         or context != transform.context
+        or operation_type != transform.operation_type
     )
     return transform_needs_versioning
 

--- a/rasgotransforms/rasgotransforms/transforms/correlation/correlation.yaml
+++ b/rasgotransforms/rasgotransforms/transforms/correlation/correlation.yaml
@@ -1,5 +1,6 @@
 name: correlation
 type: insight
+operation_type: VIZ
 context:
   chart_type: heatmap_discrete
 tags:

--- a/rasgotransforms/rasgotransforms/transforms/funnel/funnel.yaml
+++ b/rasgotransforms/rasgotransforms/transforms/funnel/funnel.yaml
@@ -1,5 +1,6 @@
 name: funnel
 type: insight
+operation_type: VIZ
 context:
   chart_type: funnel
 tags:

--- a/rasgotransforms/rasgotransforms/transforms/heatmap/heatmap.yaml
+++ b/rasgotransforms/rasgotransforms/transforms/heatmap/heatmap.yaml
@@ -1,5 +1,6 @@
 name: heatmap
 type: insight
+operation_type: VIZ
 context:
   chart_type: heatmap_continuous
 tags:

--- a/rasgotransforms/rasgotransforms/transforms/histogram/histogram.yaml
+++ b/rasgotransforms/rasgotransforms/transforms/histogram/histogram.yaml
@@ -1,5 +1,6 @@
 name: histogram
 type: insight
+operation_type: VIZ
 context:
   chart_type: series_continuous
 tags:

--- a/rasgotransforms/rasgotransforms/transforms/plot/plot.yaml
+++ b/rasgotransforms/rasgotransforms/transforms/plot/plot.yaml
@@ -1,5 +1,6 @@
 name: plot
 type: insight
+operation_type: VIZ
 context:
   chart_type: series
   default_template: true

--- a/rasgotransforms/rasgotransforms/transforms/sankey/sankey.yaml
+++ b/rasgotransforms/rasgotransforms/transforms/sankey/sankey.yaml
@@ -1,5 +1,6 @@
 name: sankey
 type: insight
+operation_type: VIZ
 context:
   chart_type: sankey
 tags:

--- a/rasgotransforms/rasgotransforms/transforms/table/table.yaml
+++ b/rasgotransforms/rasgotransforms/transforms/table/table.yaml
@@ -1,5 +1,6 @@
 name: table
 type: insight
+operation_type: VIZ
 context:
   chart_type: data_table
 tags:


### PR DESCRIPTION
The `publish_transforms.py` script that automatically runs is publishing all transforms as `operation_type: SQL`. This fix gets the operation_type from the transform yaml and publishes it. It also changes all 'VIZ' transforms to include the operation type in the yaml.