### PR TITLE
make publish action manual

### DIFF
--- a/.github/workflows/publish_accelerators.yaml
+++ b/.github/workflows/publish_accelerators.yaml
@@ -3,9 +3,12 @@
 name: Publish Accelerators
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment that accelerators will be published to'
+        default: 'all'
+        required: true
 
 jobs:
   publish-accelerators:
@@ -31,7 +34,9 @@ jobs:
           pip install -r python/requirements.txt
 
       - name: Publish Accelerators on Prod
+        if: github.event.inputs.environment == 'production' || github.event.inputs.environment == 'all'
         run: python python/publish_accelerators.py "$RASGO_COMMUNITY_API_KEY" -d production
 
       - name: Publish Accelerators on Staging
+        if: github.event.inputs.environment == 'staging' || github.event.inputs.environment == 'all'
         run: python python/publish_accelerators.py "$RASGO_STAGING_COMMUNITY_API_KEY" -d staging

--- a/.github/workflows/publish_transforms.yaml
+++ b/.github/workflows/publish_transforms.yaml
@@ -3,9 +3,12 @@
 name: Publish Transforms
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment that transforms will be published to'
+        default: 'all'
+        required: true
 
 jobs:
   publish-transforms:
@@ -21,6 +24,8 @@ jobs:
       PYTHONPATH: /__w/RasgoTransforms/RasgoTransforms
       RASGO_COMMUNITY_API_KEY: ${{ secrets.RASGO_COMMUNITY_API_KEY }}
       RASGO_STAGING_COMMUNITY_API_KEY: ${{ secrets.RASGO_STAGING_COMMUNITY_API_KEY }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.S3_UPLOAD_ACCESS_KEY }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_UPLOAD_SECRET_ACCESS_KEY }}
 
     steps:
       - uses: actions/checkout@v2
@@ -31,7 +36,13 @@ jobs:
           pip install -r python/requirements.txt
 
       - name: Publish Transforms on Prod
+        if: github.event.inputs.environment == 'production' || github.event.inputs.environment == 'all'
         run: python python/publish_transforms.py "$RASGO_COMMUNITY_API_KEY" -d production
 
       - name: Publish Transforms on Staging
+        if: github.event.inputs.environment == 'staging' || github.event.inputs.environment == 'all'
         run: python python/publish_transforms.py "$RASGO_STAGING_COMMUNITY_API_KEY" -d staging
+
+      - name: Publish Transforms to S3
+        if: github.event.inputs.environment == 's3' || github.event.inputs.environment == 'all'
+        run: python python/publish_transforms_to_s3.py

--- a/rasgotransforms/rasgotransforms/tests/valid_jinja_test.py
+++ b/rasgotransforms/rasgotransforms/tests/valid_jinja_test.py
@@ -25,6 +25,8 @@ class TestJinja:
         parsed_template = environment.parse(transform.source_code)
         parsed_arg_names = meta.find_undeclared_variables(parsed_template)
         unused_args = list(declared_arg_names.difference(parsed_arg_names))
+        if 'source_table' in unused_args:
+            unused_args.remove('source_table')
         if unused_args:
             pytest.fail(
                 f"Transform '{transform.name}' declares args [{', '.join(unused_args)}] that "


### PR DESCRIPTION
We have a problem when a transform updates requires the rasgotransform package to be updated in the api before it can be used, but merging the PR will automatically publish them. So, this updates the actions to be manually dispatched. It accepts an input for publishing to a specific environment ('staging', 's3', 'production', or 'all'). This change will also allow us to publish transforms to staging when we want to test there before publishing to prod.